### PR TITLE
Refactoring echo command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ MINISHELL_INCS= 				\
 	src/output/prompt.h			\
 	src/parser/dispatcher.h		\
 	src/commands/commands.h		\
+	src/commands/echo_utils.h	\
 
 MINISHELL_src= 					\
 	src/parser/parser.c			\

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test: $(MINISHELL_OBJS) $(TEST_FILES)
 	$(CC) $(TEST_CFLAGS) $(INC_PATH) $(MINISHELL_OBJS) $(TEST_FILES) -o $(TEST_NAME) $(LDFLAGS)
 
 acceptance_test: $(MINISHELL)
-	./tests/acceptance/main.py
+	python3 tests/acceptance/main.py
 
 clean:
 	make -C $(LIBFT_PATH) fclean

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 MINISHELL=minishell
 TEST_NAME=$(MINISHELL)_test
 CC=gcc
-CFLAGS=-Wall -Wextra -Werror
-TEST_CFLAGS=-ggdb3 $(CFLAGS)
+CFLAGS=-ggdb3 -Wall -Wextra -Werror
 INC_PATH=-I./src -I./libft
 LDFLAGS= -lreadline -L./libft -lft
 LIBFT_PATH = libft/
@@ -45,7 +44,7 @@ test_run: test
 
 test: $(MINISHELL_OBJS) $(TEST_FILES)
 	make -C $(LIBFT_PATH)
-	$(CC) $(TEST_CFLAGS) $(INC_PATH) $(MINISHELL_OBJS) $(TEST_FILES) -o $(TEST_NAME) $(LDFLAGS)
+	$(CC) $(CFLAGS) $(INC_PATH) $(MINISHELL_OBJS) $(TEST_FILES) -o $(TEST_NAME) $(LDFLAGS)
 
 acceptance_test: $(MINISHELL)
 	python3 tests/acceptance/main.py

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -1,7 +1,6 @@
 #ifndef COMMANDS_H
 # define COMMANDS_H
 # include <defines.h>
-
 # define WHITESSPACE_AND_QUOTES " 	\""
 # define WHITESSPACE " \t"
 # define N_FLAG "-n"
@@ -12,7 +11,7 @@ typedef enum e_special_chars
 	NULL_TERMINATOR = '\0'
 }	t_special_chars;
 
-typedef void (*t_output_stdout)(const char *, int);
+typedef void	(*t_output_stdout)(const char *, int);
 
 void	exit_command(t_exit_code exit_code);
 int		echo_command(const char **input, t_output_stdout output);

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -12,7 +12,9 @@ typedef enum e_special_chars
 	NULL_TERMINATOR = '\0'
 }	t_special_chars;
 
+typedef void (*t_output_stdout)(const char **);
+
 void	exit_command(t_exit_code exit_code);
-int		echo_command(const char **input);
+int		echo_command(const char **input, t_output_stdout output);
 
 #endif

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -12,7 +12,7 @@ typedef enum e_special_chars
 	NULL_TERMINATOR = '\0'
 }	t_special_chars;
 
-typedef void (*t_output_stdout)(const char **);
+typedef void (*t_output_stdout)(const char *);
 
 void	exit_command(t_exit_code exit_code);
 int		echo_command(const char **input, t_output_stdout output);

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -12,7 +12,7 @@ typedef enum e_special_chars
 	NULL_TERMINATOR = '\0'
 }	t_special_chars;
 
-typedef void (*t_output_stdout)(const char *);
+typedef void (*t_output_stdout)(const char *, int);
 
 void	exit_command(t_exit_code exit_code);
 int		echo_command(const char **input, t_output_stdout output);

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -6,12 +6,6 @@
 # define WHITESSPACE " \t"
 # define N_FLAG "-n"
 
-typedef struct s_check_quotes
-{
-	t_bool	opening;
-	t_bool	closing;
-}	t_check_quotes;
-
 typedef enum e_special_chars
 {
 	SPACE = ' ',
@@ -19,14 +13,6 @@ typedef enum e_special_chars
 }	t_special_chars;
 
 void	exit_command(t_exit_code exit_code);
-
 int		echo_command(const char **input);
-char	*get_echo_args(const char **input);
-char	**format_echo_args(const char *echo_argv);
-int		get_substr_len(const char *input);
-t_bool	has_inverted_comma_set(const char *input, t_check_quotes *quotes);
-char	**format_string_with_quotes(const char *str_w_quotes);
-void	write_space_between_words(const char *next_string);
-t_bool	parse_n_flag(const char **input);
 
 #endif

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -28,7 +28,7 @@ char	**format_echo_args(const char *echo_argv)
 	char			**split_strings;
 	t_check_quotes	quotes;
 
-	if (has_inverted_comma_set(echo_argv, &quotes))
+	if (has_double_quotes_set(echo_argv, &quotes))
 		split_strings = format_string_with_quotes(echo_argv);
 	else
 		split_strings = ft_split(echo_argv, SPACE);
@@ -51,11 +51,76 @@ void	write_echo_args(const char **strings_to_write)
 	return ;
 }
 
-void	echo_stdout(const char *string_to_write)
+void	echo_stdout(const char *string_to_write, int len)
 {
-	int	len;
-	len = ft_strlen(string_to_write);
 	write(STDOUT_FILENO, string_to_write, len);
+}
+
+
+void get_str_without_quotes(const char **input, char *stdout_buffer, int *buffer_index)
+{
+	char cur;
+	
+	skip_spaces(input);
+	cur = *(*input);
+	while (cur != DOUBLE_QUOTES && cur != '\0')
+	{
+		stdout_buffer[*buffer_index] = cur;
+		++(*input);
+		cur = *(*input);
+		++(*buffer_index);
+	}
+	if (cur == '\0' && stdout_buffer[*buffer_index - 1] == SPACE)
+		stdout_buffer[*buffer_index - 1] = '\0';
+	else
+		stdout_buffer[*buffer_index] = '\0';
+}
+
+void get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_index)
+{
+	char cur;
+	cur = *(*input);
+	if (cur != DOUBLE_QUOTES)
+		return ;
+	++(*input);
+	cur = *(*input);
+	while (cur != DOUBLE_QUOTES && cur != '\0')
+	{
+		stdout_buffer[*buffer_index] = cur;
+		++(*input);
+		cur = *(*input);
+		++(*buffer_index);
+	}
+	if (cur == '\0' && stdout_buffer[*buffer_index - 1] == SPACE)
+		stdout_buffer[*buffer_index - 1] = '\0';
+	else
+		stdout_buffer[*buffer_index] = '\0';
+}
+
+int	echo_command(const char **input, t_output_stdout output)
+{
+	const int	input_len = ft_strlen(*input);
+	char	*stdout_buffer;
+	int		i;
+
+	if (input_len == 0)
+	{
+		stdout_buffer = NULL;
+		output("", 1);
+		return (SUCCESS);
+	}
+	stdout_buffer = malloc(input_len * sizeof(char));
+	if (!stdout_buffer)
+		return (ERROR);
+	i = 0;
+	while (*(*input))
+	{
+		get_str_without_quotes(input, stdout_buffer, &i);
+		get_str_with_quotes(input, stdout_buffer, &i);
+	}
+	output(stdout_buffer, i);
+	free(stdout_buffer);
+	return (SUCCESS);
 }
 
 // int	echo_command(const char **input, t_output_stdout output)
@@ -76,10 +141,3 @@ void	echo_stdout(const char *string_to_write)
 // 	free((char *)echo_argv);
 // 	return (SUCCESS);
 // }
-
-int	echo_command(const char **input, t_output_stdout output)
-{
-	(void)input;
-	(void)output;
-	return (SUCCESS);
-}

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -10,80 +10,47 @@
 
 // possibly add clean-up function for frees()
 // possibly split formatting part
-// char	*get_echo_args(const char **input)
-// {
-// 	int		sub_str_len;
-// 	char	*echo_argv;
-
-// 	if (!input || !*input)
-// 		return (NULL);
-// 	sub_str_len = get_substr_len(*input);
-// 	echo_argv = ft_substr(*input, 0, sub_str_len);
-// 	advance_pointer(input, echo_argv);
-// 	return (echo_argv);
-// }
-
-// char	**format_echo_args(const char *echo_argv)
-// {
-// 	char			**split_strings;
-// 	t_check_quotes	quotes;
-
-// 	if (has_double_quotes_set(echo_argv, &quotes))
-// 		split_strings = format_string_with_quotes(echo_argv);
-// 	else
-// 		split_strings = ft_split(echo_argv, SPACE);
-// 	return (split_strings);
-// }
-
-// void	write_echo_args(const char **strings_to_write)
-// {
-// 	int	i;
-// 	int	len;
-
-// 	i = 0;
-// 	while (strings_to_write[i])
-// 	{
-// 		len = ft_strlen(strings_to_write[i]);
-// 		write(STDOUT_FILENO, strings_to_write[i], len);
-// 		write_space_between_words(strings_to_write[i + 1]);
-// 		i++;
-// 	}
-// 	return ;
-// }
 
 void	echo_stdout(const char *string_to_write, int len)
 {
 	write(STDOUT_FILENO, string_to_write, len);
 }
 
+void	trim_spaces_between_words(const char **input, char *stdout_buffer, int *buffer_index)
+{
+	if (isspace(*(*input)) && *(*input + 1))
+	{
+		stdout_buffer[*buffer_index] = SPACE;
+		++(*buffer_index);
+		while (isspace(*(*input)))
+			++(*input);
+	}
+}
+
+t_bool	is_double_quote(char c)
+{
+	return (c == DOUBLE_QUOTES);
+}
+
 void	get_str_without_quotes(const char **input, char *stdout_buffer, int *buffer_index)
 {
 	char	cur;
-	
+
 	skip_spaces(input);
-	cur = *(*input);
-	if (cur == DOUBLE_QUOTES)
+	if (is_double_quote(*(*input)))
 		return ;
-	while (cur != DOUBLE_QUOTES && cur != '\0')
+	cur = *(*input);
+	while (cur && !is_double_quote(cur))
 	{
 		stdout_buffer[*buffer_index] = cur;
-		++(*input);
-		if (isspace(*(*input)))
-		{
-			++(*buffer_index);
-			stdout_buffer[*buffer_index] = SPACE;
-			skip_spaces(input);
-		}	
-		cur = *(*input);
 		++(*buffer_index);
+		++(*input);
+		trim_spaces_between_words(input, stdout_buffer, buffer_index);
+		cur = *(*input);
 	}
-	if (cur == '\0' && stdout_buffer[*buffer_index - 1] == SPACE)
-		stdout_buffer[*buffer_index - 1] = '\0';
-	else
-	{
-		stdout_buffer[*buffer_index] = '\n';
-	}
+	stdout_buffer[*buffer_index] = '\n';
 }
+
 t_quotes_position	get_quotes_positions(const char *input)
 {
 	t_quotes_position quotes_position;
@@ -109,7 +76,7 @@ void	get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_in
 		strncpy(&stdout_buffer[*buffer_index], quotes.start, size);
 		*input += size + 2;
 		*buffer_index += size;
-		if (*(*input) && stdout_buffer[*buffer_index] != ' ')
+		if (*(*input) && stdout_buffer[*buffer_index] != ' ' && *(*input) != DOUBLE_QUOTES)
 		{
 			stdout_buffer[*buffer_index] = ' ';
 			++(*buffer_index);
@@ -118,54 +85,6 @@ void	get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_in
 	else if (quotes.start)
 		++(*input);
 }
-
-//  void	get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_index)
-// {
-// 	char	cur;
-// 	t_check_quotes	quotes;
-
-// 	if (*(*input) == DOUBLE_QUOTES && *(*input  + 1) == DOUBLE_QUOTES)
-// 	{
-// 		*input += 2;
-// 		return ;
-// 	}
-// 	if (!has_double_quotes_set(*input, &quotes))
-// 	{
-// 		if (quotes.opening)
-// 		{
-// 			stdout_buffer[*buffer_index] = *(*input);
-// 			++(*input);
-// 		}
-// 		return ;
-// 	}
-// 	++(*input);
-// 	cur = *(*input);
-// 	while (cur != '\0' && cur != DOUBLE_QUOTES)
-// 	{
-// 		stdout_buffer[*buffer_index] = cur;
-// 		++(*input);
-// 		cur = *(*input);
-// 		++(*buffer_index);
-// 	}
-// 	if (cur == DOUBLE_QUOTES)
-// 	{
-// 		if (*(*input + 1) == '\0')
-// 		{
-// 			stdout_buffer[*buffer_index] = '\n';
-// 			++(*input);
-// 			return ;
-// 		}
-// 		else if (*(*input + 1) != DOUBLE_QUOTES)
-// 			stdout_buffer[*buffer_index] = ' ';
-// 		else
-// 			stdout_buffer[*buffer_index] = '\n';
-// 		++(*buffer_index);
-// 		++(*input);
-// 		return ;
-// 	}
-// 	if (cur == '\0' && stdout_buffer[*buffer_index - 1] == SPACE)
-// 		stdout_buffer[*buffer_index - 1] = '\0';
-// }
 
 int	echo_command(const char **input, t_output_stdout output)
 {

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -10,56 +10,55 @@
 
 // possibly add clean-up function for frees()
 // possibly split formatting part
-char	*get_echo_args(const char **input)
-{
-	int		sub_str_len;
-	char	*echo_argv;
+// char	*get_echo_args(const char **input)
+// {
+// 	int		sub_str_len;
+// 	char	*echo_argv;
 
-	if (!input || !*input)
-		return (NULL);
-	sub_str_len = get_substr_len(*input);
-	echo_argv = ft_substr(*input, 0, sub_str_len);
-	advance_pointer(input, echo_argv);
-	return (echo_argv);
-}
+// 	if (!input || !*input)
+// 		return (NULL);
+// 	sub_str_len = get_substr_len(*input);
+// 	echo_argv = ft_substr(*input, 0, sub_str_len);
+// 	advance_pointer(input, echo_argv);
+// 	return (echo_argv);
+// }
 
-char	**format_echo_args(const char *echo_argv)
-{
-	char			**split_strings;
-	t_check_quotes	quotes;
+// char	**format_echo_args(const char *echo_argv)
+// {
+// 	char			**split_strings;
+// 	t_check_quotes	quotes;
 
-	if (has_double_quotes_set(echo_argv, &quotes))
-		split_strings = format_string_with_quotes(echo_argv);
-	else
-		split_strings = ft_split(echo_argv, SPACE);
-	return (split_strings);
-}
+// 	if (has_double_quotes_set(echo_argv, &quotes))
+// 		split_strings = format_string_with_quotes(echo_argv);
+// 	else
+// 		split_strings = ft_split(echo_argv, SPACE);
+// 	return (split_strings);
+// }
 
-void	write_echo_args(const char **strings_to_write)
-{
-	int	i;
-	int	len;
+// void	write_echo_args(const char **strings_to_write)
+// {
+// 	int	i;
+// 	int	len;
 
-	i = 0;
-	while (strings_to_write[i])
-	{
-		len = ft_strlen(strings_to_write[i]);
-		write(STDOUT_FILENO, strings_to_write[i], len);
-		write_space_between_words(strings_to_write[i + 1]);
-		i++;
-	}
-	return ;
-}
+// 	i = 0;
+// 	while (strings_to_write[i])
+// 	{
+// 		len = ft_strlen(strings_to_write[i]);
+// 		write(STDOUT_FILENO, strings_to_write[i], len);
+// 		write_space_between_words(strings_to_write[i + 1]);
+// 		i++;
+// 	}
+// 	return ;
+// }
 
 void	echo_stdout(const char *string_to_write, int len)
 {
 	write(STDOUT_FILENO, string_to_write, len);
 }
 
-
-void get_str_without_quotes(const char **input, char *stdout_buffer, int *buffer_index)
+void	get_str_without_quotes(const char **input, char *stdout_buffer, int *buffer_index)
 {
-	char cur;
+	char	cur;
 	
 	skip_spaces(input);
 	cur = *(*input);
@@ -83,50 +82,62 @@ void get_str_without_quotes(const char **input, char *stdout_buffer, int *buffer
 	else
 	{
 		stdout_buffer[*buffer_index] = '\n';
-		stdout_buffer[*buffer_index + 1] = '\0';
 	}
 }
 
-void get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_index)
+void	get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_index)
 {
-	char cur;
-	cur = *(*input);
-	if (cur != DOUBLE_QUOTES)
+	char	cur;
+	t_check_quotes	quotes;
+	if (*(*input) == DOUBLE_QUOTES && *(*input  + 1) == DOUBLE_QUOTES)
+	{
+		*input += 2;
 		return ;
+	}
+	if (!has_double_quotes_set(*input, &quotes))
+	{
+		if (quotes.opening)
+		{
+			stdout_buffer[*buffer_index] = *(*input);
+			++(*input);
+		}
+		return ;
+	}
 	++(*input);
 	cur = *(*input);
-	while (cur != '\0')
+	while (cur != '\0' && cur != DOUBLE_QUOTES)
 	{
 		stdout_buffer[*buffer_index] = cur;
 		++(*input);
 		cur = *(*input);
 		++(*buffer_index);
-		if (cur == DOUBLE_QUOTES)
+	}
+	if (cur == DOUBLE_QUOTES)
+	{
+		if (*(*input + 1) == '\0')
 		{
-			if (*(*input + 1) == '\0')
-			{
-				stdout_buffer[*buffer_index] = '\n';
-				return ;
-			}
-			else
-				stdout_buffer[*buffer_index] = ' ';
-			++(*buffer_index);
+			stdout_buffer[*buffer_index] = '\n';
 			++(*input);
 			return ;
 		}
+		else if (*(*input + 1) != DOUBLE_QUOTES)
+			stdout_buffer[*buffer_index] = ' ';
+		else
+			stdout_buffer[*buffer_index] = '\n';
+		++(*buffer_index);
+		++(*input);
+		return ;
 	}
 	if (cur == '\0' && stdout_buffer[*buffer_index - 1] == SPACE)
 		stdout_buffer[*buffer_index - 1] = '\0';
-	else
-		stdout_buffer[*buffer_index] = '\n';
 }
 
 int	echo_command(const char **input, t_output_stdout output)
 {
 	const t_bool	has_n_flag = parse_n_flag(input);
-	const int	input_len = ft_strlen(*input);
-	char	*stdout_buffer;
-	int		i;
+	const int		input_len = ft_strlen(*input);
+	char			*stdout_buffer;
+	int				i;
 
 	if (input_len == 0)
 	{
@@ -146,10 +157,9 @@ int	echo_command(const char **input, t_output_stdout output)
 		get_str_without_quotes(input, stdout_buffer, &i);
 	}
 	if (has_n_flag)
-	{
 		stdout_buffer[i] = '\0';
-		++i;
-	}
+	++i;
+	// printf("Buffer: |%s|", stdout_buffer);
 	output(stdout_buffer, i);
 	free(stdout_buffer);
 	return (SUCCESS);

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -51,9 +51,7 @@ void	write_echo_args(const char **strings_to_write)
 	return ;
 }
 
-typedef void (*t_output_stdout)(const char **);
-
-int	echo_command(const char **input)
+int	echo_command(const char **input, t_output_stdout output)
 {
 	const t_bool	has_n_flag = parse_n_flag(input);
 	const char		*echo_argv = get_echo_args(input);
@@ -64,7 +62,7 @@ int	echo_command(const char **input)
 	strings_to_write = format_echo_args(echo_argv);
 	if (strings_to_write == NULL)
 		return (ERROR);
-	write_echo_args((const char **)strings_to_write);
+	output((const char **)strings_to_write);
 	if (!has_n_flag)
 		write(STDOUT_FILENO, "\n", 1);
 	free_split(strings_to_write);

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -84,53 +84,88 @@ void	get_str_without_quotes(const char **input, char *stdout_buffer, int *buffer
 		stdout_buffer[*buffer_index] = '\n';
 	}
 }
+t_quotes_position	get_quotes_positions(const char *input)
+{
+	t_quotes_position quotes_position;
+
+	if (*input == DOUBLE_QUOTES)
+	{
+		++input;
+		quotes_position.start = input;
+		quotes_position.end = ft_strchr(input, DOUBLE_QUOTES);
+		return (quotes_position);
+	}
+	quotes_position.start = NULL;
+	quotes_position.end = NULL;
+	return (quotes_position);
+}
 
 void	get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_index)
 {
-	char	cur;
-	t_check_quotes	quotes;
-	if (*(*input) == DOUBLE_QUOTES && *(*input  + 1) == DOUBLE_QUOTES)
+	t_quotes_position	quotes = get_quotes_positions(*input);
+	int size = quotes.end - quotes.start;
+	if (quotes.start && quotes.end)
 	{
-		*input += 2;
-		return ;
-	}
-	if (!has_double_quotes_set(*input, &quotes))
-	{
-		if (quotes.opening)
+		strncpy(&stdout_buffer[*buffer_index], quotes.start, size);
+		*input += size + 2;
+		*buffer_index += size;
+		if (*(*input) && stdout_buffer[*buffer_index] != ' ')
 		{
-			stdout_buffer[*buffer_index] = *(*input);
-			++(*input);
-		}
-		return ;
-	}
-	++(*input);
-	cur = *(*input);
-	while (cur != '\0' && cur != DOUBLE_QUOTES)
-	{
-		stdout_buffer[*buffer_index] = cur;
-		++(*input);
-		cur = *(*input);
-		++(*buffer_index);
-	}
-	if (cur == DOUBLE_QUOTES)
-	{
-		if (*(*input + 1) == '\0')
-		{
-			stdout_buffer[*buffer_index] = '\n';
-			++(*input);
-			return ;
-		}
-		else if (*(*input + 1) != DOUBLE_QUOTES)
 			stdout_buffer[*buffer_index] = ' ';
-		else
-			stdout_buffer[*buffer_index] = '\n';
-		++(*buffer_index);
-		++(*input);
-		return ;
+			++(*buffer_index);
+		}
 	}
-	if (cur == '\0' && stdout_buffer[*buffer_index - 1] == SPACE)
-		stdout_buffer[*buffer_index - 1] = '\0';
+	else if (quotes.start)
+		++(*input);
 }
+
+//  void	get_str_with_quotes(const char **input, char *stdout_buffer, int *buffer_index)
+// {
+// 	char	cur;
+// 	t_check_quotes	quotes;
+
+// 	if (*(*input) == DOUBLE_QUOTES && *(*input  + 1) == DOUBLE_QUOTES)
+// 	{
+// 		*input += 2;
+// 		return ;
+// 	}
+// 	if (!has_double_quotes_set(*input, &quotes))
+// 	{
+// 		if (quotes.opening)
+// 		{
+// 			stdout_buffer[*buffer_index] = *(*input);
+// 			++(*input);
+// 		}
+// 		return ;
+// 	}
+// 	++(*input);
+// 	cur = *(*input);
+// 	while (cur != '\0' && cur != DOUBLE_QUOTES)
+// 	{
+// 		stdout_buffer[*buffer_index] = cur;
+// 		++(*input);
+// 		cur = *(*input);
+// 		++(*buffer_index);
+// 	}
+// 	if (cur == DOUBLE_QUOTES)
+// 	{
+// 		if (*(*input + 1) == '\0')
+// 		{
+// 			stdout_buffer[*buffer_index] = '\n';
+// 			++(*input);
+// 			return ;
+// 		}
+// 		else if (*(*input + 1) != DOUBLE_QUOTES)
+// 			stdout_buffer[*buffer_index] = ' ';
+// 		else
+// 			stdout_buffer[*buffer_index] = '\n';
+// 		++(*buffer_index);
+// 		++(*input);
+// 		return ;
+// 	}
+// 	if (cur == '\0' && stdout_buffer[*buffer_index - 1] == SPACE)
+// 		stdout_buffer[*buffer_index - 1] = '\0';
+// }
 
 int	echo_command(const char **input, t_output_stdout output)
 {
@@ -148,6 +183,7 @@ int	echo_command(const char **input, t_output_stdout output)
 		return (SUCCESS);
 	}
 	stdout_buffer = malloc(input_len * sizeof(char));
+	ft_bzero(stdout_buffer, input_len);
 	if (!stdout_buffer)
 		return (ERROR);
 	i = 0;
@@ -159,7 +195,6 @@ int	echo_command(const char **input, t_output_stdout output)
 	if (has_n_flag)
 		stdout_buffer[i] = '\0';
 	++i;
-	// printf("Buffer: |%s|", stdout_buffer);
 	output(stdout_buffer, i);
 	free(stdout_buffer);
 	return (SUCCESS);

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -6,6 +6,7 @@
 #include <ctype.h> 
 #include <libft.h>
 #include <parser/parser.h>
+#include <commands/echo_utils.h>
 
 // possibly add clean-up function for frees()
 // possibly split formatting part

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -50,7 +50,7 @@ static void	get_str_with_quotes(const char **input,
 {
 	const t_quotes_position	quotes = get_quotes_positions(*input);
 	const int				size = quotes.end - quotes.start;
-	const int 				num_quotes = 2;
+	const int				num_quotes = 2;
 
 	if (quotes.start && quotes.end)
 	{

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -51,21 +51,35 @@ void	write_echo_args(const char **strings_to_write)
 	return ;
 }
 
+void	echo_stdout(const char *string_to_write)
+{
+	int	len;
+	len = ft_strlen(string_to_write);
+	write(STDOUT_FILENO, string_to_write, len);
+}
+
+// int	echo_command(const char **input, t_output_stdout output)
+// {
+// 	const t_bool	has_n_flag = parse_n_flag(input);
+// 	const char		*echo_argv = get_echo_args(input);
+// 	char			**strings_to_write;
+
+// 	if (!echo_argv)
+// 		return (ERROR);
+// 	strings_to_write = format_echo_args(echo_argv);
+// 	if (strings_to_write == NULL)
+// 		return (ERROR);
+// 	output((const char **)strings_to_write);
+// 	if (!has_n_flag)
+// 		write(STDOUT_FILENO, "\n", 1);
+// 	free_split(strings_to_write);
+// 	free((char *)echo_argv);
+// 	return (SUCCESS);
+// }
+
 int	echo_command(const char **input, t_output_stdout output)
 {
-	const t_bool	has_n_flag = parse_n_flag(input);
-	const char		*echo_argv = get_echo_args(input);
-	char			**strings_to_write;
-
-	if (!echo_argv)
-		return (ERROR);
-	strings_to_write = format_echo_args(echo_argv);
-	if (strings_to_write == NULL)
-		return (ERROR);
-	output((const char **)strings_to_write);
-	if (!has_n_flag)
-		write(STDOUT_FILENO, "\n", 1);
-	free_split(strings_to_write);
-	free((char *)echo_argv);
+	(void)input;
+	(void)output;
 	return (SUCCESS);
 }

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -50,6 +50,8 @@ void	write_echo_args(const char **strings_to_write)
 	return ;
 }
 
+typedef void (*t_output_stdout)(const char **);
+
 int	echo_command(const char **input)
 {
 	const t_bool	has_n_flag = parse_n_flag(input);

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -50,11 +50,12 @@ static void	get_str_with_quotes(const char **input,
 {
 	const t_quotes_position	quotes = get_quotes_positions(*input);
 	const int				size = quotes.end - quotes.start;
+	const int 				num_quotes = 2;
 
 	if (quotes.start && quotes.end)
 	{
 		strncpy(&stdout_buffer[*buffer_index], quotes.start, size);
-		*input += size + 2;
+		*input += size + num_quotes;
 		*buffer_index += size;
 		add_space_between_strs(*(*input), stdout_buffer, buffer_index);
 	}
@@ -76,23 +77,23 @@ int	echo_command(const char **input, t_output_stdout output)
 	const t_bool	has_n_flag = parse_n_flag(input);
 	const int		input_len = ft_strlen(*input);
 	char			*stdout_buffer;
-	int				i;
+	int				buffer_index;
 
 	if (input_len == 0)
 		return (handle_empty_str(has_n_flag, output));
 	stdout_buffer = ft_calloc(input_len, sizeof(char));
 	if (!stdout_buffer)
 		return (ERROR);
-	i = 0;
+	buffer_index = 0;
 	while (*(*input))
 	{
-		get_str_with_quotes(input, stdout_buffer, &i);
-		get_str_without_quotes(input, stdout_buffer, &i);
+		get_str_with_quotes(input, stdout_buffer, &buffer_index);
+		get_str_without_quotes(input, stdout_buffer, &buffer_index);
 	}
 	if (has_n_flag)
-		stdout_buffer[i] = '\0';
-	++i;
-	output(stdout_buffer, i);
+		stdout_buffer[buffer_index] = '\0';
+	++buffer_index;
+	output(stdout_buffer, buffer_index);
 	free(stdout_buffer);
 	return (SUCCESS);
 }

--- a/src/commands/echo_utils.c
+++ b/src/commands/echo_utils.c
@@ -2,6 +2,7 @@
 #include <ctype.h>
 #include <libft.h>
 #include <parser/parser.h>
+#include <commands/echo_utils.h>
 
 int	get_substr_len(const char *input)
 {

--- a/src/commands/echo_utils.c
+++ b/src/commands/echo_utils.c
@@ -22,15 +22,19 @@ int	get_substr_len(const char *input)
 
 t_bool	has_inverted_comma_set(const char *input, t_check_quotes *quotes)
 {
+	char cur;
+
 	quotes->opening = FALSE;
 	quotes->closing = FALSE;
-	while (*input)
+	cur = *input;
+	while (cur)
 	{
-		if (*input == INVERTED_COMMA && quotes->opening)
+		if (cur == INVERTED_COMMA && quotes->opening)
 			quotes->closing = TRUE;
-		else if (*input == INVERTED_COMMA)
+		else if (cur == INVERTED_COMMA)
 			quotes->opening = TRUE;
 		input++;
+		cur = *input;
 	}
 	if (quotes->opening && quotes->closing)
 		return (TRUE);

--- a/src/commands/echo_utils.c
+++ b/src/commands/echo_utils.c
@@ -21,7 +21,7 @@ int	get_substr_len(const char *input)
 	return (0);
 }
 
-t_bool	has_inverted_comma_set(const char *input, t_check_quotes *quotes)
+t_bool	has_double_quotes_set(const char *input, t_check_quotes *quotes)
 {
 	char cur;
 
@@ -30,9 +30,9 @@ t_bool	has_inverted_comma_set(const char *input, t_check_quotes *quotes)
 	cur = *input;
 	while (cur)
 	{
-		if (cur == INVERTED_COMMA && quotes->opening)
+		if (cur == DOUBLE_QUOTES && quotes->opening)
 			quotes->closing = TRUE;
-		else if (cur == INVERTED_COMMA)
+		else if (cur == DOUBLE_QUOTES)
 			quotes->opening = TRUE;
 		input++;
 		cur = *input;

--- a/src/commands/echo_utils.c
+++ b/src/commands/echo_utils.c
@@ -4,55 +4,20 @@
 #include <parser/parser.h>
 #include <commands/echo_utils.h>
 
-int	get_substr_len(const char *input)
+t_quotes_position	get_quotes_positions(const char *input)
 {
-	const int	strlen = ft_strlen(input);
-	int			i;
+	t_quotes_position	quotes_position;
 
-	i = 0;
-	while (input[i])
+	if (*input == DOUBLE_QUOTES)
 	{
-		if (input[i] == '|')
-			return (i);
-		i++;
+		++input;
+		quotes_position.start = input;
+		quotes_position.end = ft_strchr(input, DOUBLE_QUOTES);
+		return (quotes_position);
 	}
-	if (i == strlen)
-		return (strlen);
-	return (0);
-}
-
-t_bool	has_double_quotes_set(const char *input, t_check_quotes *quotes)
-{
-	char	cur;
-
-	quotes->opening = *input == DOUBLE_QUOTES;
-	quotes->closing = FALSE;
-	++input;
-	cur = *input;
-	while (cur)
-	{
-		if (cur == DOUBLE_QUOTES && quotes->opening)
-			return (TRUE);
-		input++;
-		cur = *input;
-	}
-	return (quotes->opening && quotes->closing);
-}
-
-char	**format_string_with_quotes(const char *str_w_quotes)
-{
-	char		**split_strings;
-	const char	*clean_str = ft_strtrim(str_w_quotes, WHITESSPACE_AND_QUOTES);
-
-	split_strings = ft_split(clean_str, NULL_TERMINATOR);
-	free((char *)clean_str);
-	return (split_strings);
-}
-
-void	write_space_between_words(const char *next_string)
-{
-	if (next_string)
-		write(STDOUT_FILENO, " ", 1);
+	quotes_position.start = NULL;
+	quotes_position.end = NULL;
+	return (quotes_position);
 }
 
 t_bool	parse_n_flag(const char **input)
@@ -65,4 +30,27 @@ t_bool	parse_n_flag(const char **input)
 		return (TRUE);
 	}
 	return (FALSE);
+}
+
+void	echo_stdout(const char *string_to_write, int len)
+{
+	write(STDOUT_FILENO, string_to_write, len);
+}
+
+void	trim_extra_spaces_between_words(const char **input,
+										char *stdout_buffer,
+										int *buffer_index)
+{
+	if (isspace(*(*input)) && *(*input + 1))
+	{
+		stdout_buffer[*buffer_index] = SPACE;
+		++(*buffer_index);
+		while (isspace(*(*input)))
+			++(*input);
+	}
+}
+
+t_bool	is_double_quote(char c)
+{
+	return (c == DOUBLE_QUOTES);
 }

--- a/src/commands/echo_utils.c
+++ b/src/commands/echo_utils.c
@@ -23,23 +23,20 @@ int	get_substr_len(const char *input)
 
 t_bool	has_double_quotes_set(const char *input, t_check_quotes *quotes)
 {
-	char cur;
+	char	cur;
 
-	quotes->opening = FALSE;
+	quotes->opening = *input == DOUBLE_QUOTES;
 	quotes->closing = FALSE;
+	++input;
 	cur = *input;
 	while (cur)
 	{
 		if (cur == DOUBLE_QUOTES && quotes->opening)
-			quotes->closing = TRUE;
-		else if (cur == DOUBLE_QUOTES)
-			quotes->opening = TRUE;
+			return (TRUE);
 		input++;
 		cur = *input;
 	}
-	if (quotes->opening && quotes->closing)
-		return (TRUE);
-	return (FALSE);
+	return (quotes->opening && quotes->closing);
 }
 
 char	**format_string_with_quotes(const char *str_w_quotes)

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -8,8 +8,16 @@ typedef struct s_check_quotes
 	t_bool	closing;
 }	t_check_quotes;
 
+typedef struct s_quotes_position
+{
+	const char *start;
+	const char *end;
+}	t_quotes_position;
+
+
 int		get_substr_len(const char *input);
 t_bool	has_double_quotes_set(const char *input, t_check_quotes *quotes);
+t_quotes_position	get_quotes_positions(const char *input);
 char	**format_string_with_quotes(const char *str_w_quotes);
 void	write_space_between_words(const char *next_string);
 t_bool	parse_n_flag(const char **input);

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -13,5 +13,6 @@ t_bool	has_inverted_comma_set(const char *input, t_check_quotes *quotes);
 char	**format_string_with_quotes(const char *str_w_quotes);
 void	write_space_between_words(const char *next_string);
 t_bool	parse_n_flag(const char **input);
+void	write_echo_args(const char **strings_to_write);
 
 #endif

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -10,18 +10,16 @@ typedef struct s_check_quotes
 
 typedef struct s_quotes_position
 {
-	const char *start;
-	const char *end;
+	const char	*start;
+	const char	*end;
 }	t_quotes_position;
 
-
-int		get_substr_len(const char *input);
-t_bool	has_double_quotes_set(const char *input, t_check_quotes *quotes);
 t_quotes_position	get_quotes_positions(const char *input);
-char	**format_string_with_quotes(const char *str_w_quotes);
-void	write_space_between_words(const char *next_string);
-t_bool	parse_n_flag(const char **input);
-void	write_echo_args(const char **strings_to_write);
-void	echo_stdout(const char *string_to_write, int len);
+t_bool				parse_n_flag(const char **input);
+void				echo_stdout(const char *string_to_write, int len);
+void				trim_extra_spaces_between_words(const char **input,
+						char *stdout_buffer,
+						int *buffer_index);
+t_bool				is_double_quote(char c);
 
 #endif

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -1,6 +1,6 @@
 #ifndef ECHO_UTILS_H
-#define ECHO_UTILS_H
-#include <defines.h>
+# define ECHO_UTILS_H
+# include <defines.h>
 
 typedef struct s_check_quotes
 {
@@ -8,7 +8,7 @@ typedef struct s_check_quotes
 	t_bool	closing;
 }	t_check_quotes;
 
-int	get_substr_len(const char *input);
+int		get_substr_len(const char *input);
 t_bool	has_double_quotes_set(const char *input, t_check_quotes *quotes);
 char	**format_string_with_quotes(const char *str_w_quotes);
 void	write_space_between_words(const char *next_string);

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -9,11 +9,11 @@ typedef struct s_check_quotes
 }	t_check_quotes;
 
 int	get_substr_len(const char *input);
-t_bool	has_inverted_comma_set(const char *input, t_check_quotes *quotes);
+t_bool	has_double_quotes_set(const char *input, t_check_quotes *quotes);
 char	**format_string_with_quotes(const char *str_w_quotes);
 void	write_space_between_words(const char *next_string);
 t_bool	parse_n_flag(const char **input);
 void	write_echo_args(const char **strings_to_write);
-void	echo_stdout(const char *string_to_write);
+void	echo_stdout(const char *string_to_write, int len);
 
 #endif

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -14,5 +14,6 @@ char	**format_string_with_quotes(const char *str_w_quotes);
 void	write_space_between_words(const char *next_string);
 t_bool	parse_n_flag(const char **input);
 void	write_echo_args(const char **strings_to_write);
+void	echo_stdout(const char *string_to_write);
 
 #endif

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -1,0 +1,17 @@
+#ifndef ECHO_UTILS_H
+#define ECHO_UTILS_H
+#include <defines.h>
+
+typedef struct s_check_quotes
+{
+	t_bool	opening;
+	t_bool	closing;
+}	t_check_quotes;
+
+int	get_substr_len(const char *input);
+t_bool	has_inverted_comma_set(const char *input, t_check_quotes *quotes);
+char	**format_string_with_quotes(const char *str_w_quotes);
+void	write_space_between_words(const char *next_string);
+t_bool	parse_n_flag(const char **input);
+
+#endif

--- a/src/defines.h
+++ b/src/defines.h
@@ -2,7 +2,7 @@
 # define DEFINES_H
 
 # define NEW_LINE "\n"
-# define INVERTED_COMMA '\"'
+# define DOUBLE_QUOTES '\"'
 
 typedef enum e_bool
 {

--- a/src/defines.h
+++ b/src/defines.h
@@ -2,7 +2,7 @@
 # define DEFINES_H
 
 # define NEW_LINE "\n"
-# define DOUBLE_QUOTES '\"'
+# define DOUBLE_QUOTES '"'
 
 typedef enum e_bool
 {

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -1,5 +1,6 @@
 #include <parser/dispatcher.h>
 #include <commands/commands.h>
+#include <commands/echo_utils.h>
 #include <stdio.h>
 
 t_bool	dispatch_commands(const char **input, t_command command)
@@ -8,6 +9,6 @@ t_bool	dispatch_commands(const char **input, t_command command)
 	if (command == EXIT)
 		exit_command(SUCCESS);
 	else if (command == ECHO)
-		return (echo_command(input));
+		return (echo_command(input, write_echo_args));
 	return (FALSE);
 }

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -9,6 +9,6 @@ t_bool	dispatch_commands(const char **input, t_command command)
 	if (command == EXIT)
 		exit_command(SUCCESS);
 	else if (command == ECHO)
-		return (echo_command(input, write_echo_args));
+		return (echo_command(input, echo_stdout));
 	return (FALSE);
 }

--- a/tests/acceptance/echo_feature_test.py
+++ b/tests/acceptance/echo_feature_test.py
@@ -88,20 +88,20 @@ class TestEcho(unittest.TestCase):
 		self.assertEqual(bash_output.split("\n")[1], minishell_output.split("\n")[3], "{}Should display a Hello\\n,  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[3], RESET))
 	
 	def test_str_with_quotes(self):
-		self.echoFile.appendCommand('echo "Hello      you" \n')
+		self.echoFile.appendCommand('echo "Hello      you"\n')
 		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
 		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
 		self.assertEqual(bash_output.split("\n")[0], minishell_output.split("\n")[1], "{}Should display a 'Hello      you',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))
 
-	def test_str_with_quotes_and_n_flag(self):
-		self.echoFile.appendCommand('echo -n "Hello      you" \n')
-		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
-		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
-		self.assertEqual("Hello      youBestShellEver: exit", minishell_output.split("\n")[1], "{}Should display a 'Hello      youBestShellEver: exit',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))
+	# def test_str_with_quotes_and_n_flag(self):
+	# 	self.echoFile.appendCommand('echo -n "Hello      you"\n')
+	# 	bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+	# 	minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+	# 	self.assertEqual("Hello      youBestShellEver: exit", minishell_output.split("\n")[1], "{}Should display a 'Hello      youBestShellEver: exit',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))
 
-	def test_str_with_quotes_and_spaces_in_the_beginnig(self):
-		self.echoFile.appendCommand('echo "     Hello      you" \n')
-		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
-		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
-		# print(minishell_output.split("\n"))
-		self.assertEqual("     Hello      you", minishell_output.split("\n")[1], "{}Should display a '     Hello      you',  but it displyed:  {}'{}'{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))
+	# def test_str_with_quotes_and_spaces_in_the_beginnig(self):
+	# 	self.echoFile.appendCommand('echo "     Hello      you" \n')
+	# 	bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+	# 	minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+	# 	print(minishell_output.split("\n")[1])
+	# 	self.assertEqual("     Hello      you", minishell_output.split("\n")[1], "{}Should display a '     Hello      you',  but it displyed:  {}'{}'{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))

--- a/tests/acceptance/echo_feature_test.py
+++ b/tests/acceptance/echo_feature_test.py
@@ -103,5 +103,5 @@ class TestEcho(unittest.TestCase):
 		self.echoFile.appendCommand('echo "     Hello      you" \n')
 		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
 		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
-		print(minishell_output.split("\n"))
+		# print(minishell_output.split("\n"))
 		self.assertEqual("     Hello      you", minishell_output.split("\n")[1], "{}Should display a '     Hello      you',  but it displyed:  {}'{}'{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))

--- a/tests/acceptance/echo_feature_test.py
+++ b/tests/acceptance/echo_feature_test.py
@@ -15,87 +15,93 @@ RESET = "\033[0m"
 RUN_CAT_COMMAND = "cat {}"
 LAUNCH_MINISHELL_COMMAND = "./minishell"
 def printTestName(testName):
-    print("\n{}======================= {}{}{}".format(LIGHT_PURPLE, LIGHT_YELLOW, testName, RESET))
+	print("\n{}======================= {}{}{}".format(LIGHT_PURPLE, LIGHT_YELLOW, testName, RESET))
 
 class File:
-    
-    def __init__(self, filename):
-        self.filename = filename
-        f = open(self.filename, "w")
-        f.close()
+	
+	def __init__(self, filename):
+		self.filename = filename
+		f = open(self.filename, "w")
+		f.close()
 
-    def appendCommand(self, command):
-        with open(self.filename, "a") as f:
-            f.write(command)
+	def appendCommand(self, command):
+		with open(self.filename, "a") as f:
+			f.write(command)
 
-    def getFirstLine(self):
-        with open(self.filename, "r") as f:
-            return f.read()
+	def getFirstLine(self):
+		with open(self.filename, "r") as f:
+			return f.read()
 
 class Bash:
 
-    @classmethod
-    def runInputFile(cls, file):
-        shell_input = file.getFirstLine()
-        return subprocess.check_output(shell_input, shell=True)
+	@classmethod
+	def runInputFile(cls, file):
+		shell_input = file.getFirstLine()
+		return subprocess.check_output(shell_input, shell=True)
 
 class Minishell:
 
-    @classmethod
-    def runInputFile(cls, file):
-        file.appendCommand("exit\n")
-        cat_process = Popen(RUN_CAT_COMMAND.format(file.filename).split(), stdout=PIPE)
-        minishell_process = subprocess.check_output(LAUNCH_MINISHELL_COMMAND, stdin=cat_process.stdout, shell=True)
-        stdout, strerr = cat_process.communicate()
-        assert strerr is None, "cat process returned error"
-        return minishell_process
+	@classmethod
+	def runInputFile(cls, file):
+		file.appendCommand("exit\n")
+		cat_process = Popen(RUN_CAT_COMMAND.format(file.filename).split(), stdout=PIPE)
+		minishell_process = subprocess.check_output(LAUNCH_MINISHELL_COMMAND, stdin=cat_process.stdout, shell=True)
+		stdout, strerr = cat_process.communicate()
+		assert strerr is None, "cat process returned error"
+		return minishell_process
 
 
 class TestEcho(unittest.TestCase):
 
-    def setUp(self):
-        self.filename = "tests/acceptance/echo_feature.txt"
-        self.echoFile = File(self.filename)
-    
-    def tearDown(self):
-        os.remove(self.filename)
+	def setUp(self):
+		self.filename = "tests/acceptance/echo_feature.txt"
+		self.echoFile = File(self.filename)
+	
+	def tearDown(self):
+		os.remove(self.filename)
 
-    def test_echo(self):
-        printTestName(self.test_echo.__name__)
+	def test_echo(self):
+		printTestName(self.test_echo.__name__)
 
-    def test_empty(self):
-        self.echoFile.appendCommand("echo\n")
-        bash_output = Bash.runInputFile(self.echoFile)
-        minishell_output = Minishell.runInputFile(self.echoFile)
-        bash_len = len(bash_output.decode("utf-8").split())
-        expected_split_len = 4 #4 because it will print "BestShellEver" 2 times, plus "echo", plus "exit", the '\n' doesnt count
-        minishell_len = len(minishell_output.decode("utf-8").split()) - expected_split_len
-        self.assertEqual(minishell_len, bash_len, "{}Should display a \\n line, but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
+	def test_empty(self):
+		self.echoFile.appendCommand("echo\n")
+		bash_output = Bash.runInputFile(self.echoFile)
+		minishell_output = Minishell.runInputFile(self.echoFile)
+		bash_len = len(bash_output.decode("utf-8").split())
+		expected_split_len = 4 #4 because it will print "BestShellEver" 2 times, plus "echo", plus "exit", the '\n' doesnt count
+		minishell_len = len(minishell_output.decode("utf-8").split()) - expected_split_len
+		self.assertEqual(minishell_len, bash_len, "{}Should display a \\n line, but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
 
-    def test_empty_quotes(self):
-        self.echoFile.appendCommand('echo ""\n')
-        bash_output = Bash.runInputFile(self.echoFile)
-        minishell_output = Minishell.runInputFile(self.echoFile)
-        bash_len = len(bash_output.decode("utf-8").split())
-        expected_len = 5 #5 because it will print "BestShellEver" 2 times, plus "echo", plus "", plus "exit", the '\n' doesnt count
-        minishell_len = len(minishell_output.decode("utf-8").split()) - expected_len
-        self.assertEqual(minishell_len, bash_len, "{}Should display a \\n line, but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
-    
-    def test_str_without_quotes(self):
-        self.echoFile.appendCommand("echo Hello\n")
-        bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
-        minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
-        self.assertEqual(bash_output.split("\n")[1], minishell_output.split("\n")[3], "{}Should display a Hello\\n,  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
-    
-    def test_str_with_quotes(self):
-        self.echoFile.appendCommand('echo "Hello      you" \n')
-        bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
-        minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
-        self.assertEqual(bash_output.split("\n")[0], minishell_output.split("\n")[1], "{}Should display a 'Hello      you',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
+	def test_empty_quotes(self):
+		self.echoFile.appendCommand('echo ""\n')
+		bash_output = Bash.runInputFile(self.echoFile)
+		minishell_output = Minishell.runInputFile(self.echoFile)
+		bash_len = len(bash_output.decode("utf-8").split())
+		expected_len = 5 #5 because it will print "BestShellEver" 2 times, plus "echo", plus "", plus "exit", the '\n' doesnt count
+		minishell_len = len(minishell_output.decode("utf-8").split()) - expected_len
+		self.assertEqual(minishell_len, bash_len, "{}Should display a \\n line, but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
+	
+	def test_str_without_quotes(self):
+		self.echoFile.appendCommand("echo Hello\n")
+		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+		self.assertEqual(bash_output.split("\n")[1], minishell_output.split("\n")[3], "{}Should display a Hello\\n,  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[3], RESET))
+	
+	def test_str_with_quotes(self):
+		self.echoFile.appendCommand('echo "Hello      you" \n')
+		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+		self.assertEqual(bash_output.split("\n")[0], minishell_output.split("\n")[1], "{}Should display a 'Hello      you',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))
 
-    def test_str_with_quotes(self):
-        self.echoFile.appendCommand('echo -n "Hello      you" \n')
-        bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
-        minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
-        self.assertEqual("Hello      youBestShellEver: exit", minishell_output.split("\n")[1], "{}Should display a 'Hello      you',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
-        
+	def test_str_with_quotes_and_n_flag(self):
+		self.echoFile.appendCommand('echo -n "Hello      you" \n')
+		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+		self.assertEqual("Hello      youBestShellEver: exit", minishell_output.split("\n")[1], "{}Should display a 'Hello      youBestShellEver: exit',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))
+
+	def test_str_with_quotes_and_spaces_in_the_beginnig(self):
+		self.echoFile.appendCommand('echo "     Hello      you" \n')
+		bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+		minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+		print(minishell_output.split("\n"))
+		self.assertEqual("     Hello      you", minishell_output.split("\n")[1], "{}Should display a '     Hello      you',  but it displyed:  {}'{}'{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output.split("\n")[1], RESET))

--- a/tests/acceptance/echo_feature_test.py
+++ b/tests/acceptance/echo_feature_test.py
@@ -80,9 +80,22 @@ class TestEcho(unittest.TestCase):
         expected_len = 5 #5 because it will print "BestShellEver" 2 times, plus "echo", plus "", plus "exit", the '\n' doesnt count
         minishell_len = len(minishell_output.decode("utf-8").split()) - expected_len
         self.assertEqual(minishell_len, bash_len, "{}Should display a \\n line, but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
+    
     def test_str_without_quotes(self):
-        # self.echoFile.appendCommand("echo Hello\n")
-        # bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
-        # minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
-        # self.assertEqual(bash_output, minishell_output.split()[3], "{}Should display a Hello\\n,  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
-        pass
+        self.echoFile.appendCommand("echo Hello\n")
+        bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+        minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+        self.assertEqual(bash_output.split("\n")[1], minishell_output.split("\n")[3], "{}Should display a Hello\\n,  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
+    
+    def test_str_with_quotes(self):
+        self.echoFile.appendCommand('echo "Hello      you" \n')
+        bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+        minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+        self.assertEqual(bash_output.split("\n")[0], minishell_output.split("\n")[1], "{}Should display a 'Hello      you',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
+
+    def test_str_with_quotes(self):
+        self.echoFile.appendCommand('echo -n "Hello      you" \n')
+        bash_output = Bash.runInputFile(self.echoFile).decode("utf-8")
+        minishell_output = Minishell.runInputFile(self.echoFile).decode("utf-8")
+        self.assertEqual("Hello      youBestShellEver: exit", minishell_output.split("\n")[1], "{}Should display a 'Hello      you',  but it displyed:  {}{}{}".format(LIGHT_RED, LIGHT_YELLOW, minishell_output, RESET))
+        

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -18,12 +18,6 @@ CTEST(echo_test, returns_true_with_emptry_str_input)
 	ASSERT_EQUAL(SUCCESS, echo_command(&input));
 }
 
-// CTEST(echo_utils_test, format_string_test)
-// {
-// 	const char *input = "";
-// 	ASSERT_NOT_NULL(get_echo_args(&input));
-// }
-
 // CTEST(echo_utils_test, empty_substr_len_test)
 // {
 // 	const char *input = "";

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -12,13 +12,9 @@
 // (	"	whitespace         4 dddaaaaaayyyyyys, with quotes      ")
 // (	"	quotes with \"\" quotes"      ")
 
-void	fake_output(const char **strings_to_write)
+void	fake_output(const char *string_to_write)
 {
-	for (int i = 0; strings_to_write[i] != NULL; ++i)
-	{
-		printf(strings_to_write[i]);
-		printf(" ");
-	}
+	ASSERT_STR("", string_to_write);
 }
 
 CTEST(echo_test, returns_true_with_emptry_str_input)

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -18,104 +18,119 @@ CTEST(echo_test, returns_true_with_emptry_str_input)
 	ASSERT_EQUAL(SUCCESS, echo_command(&input));
 }
 
-CTEST(echo_utils_test, format_string_test)
-{
-	const char *input = "";
-	ASSERT_NOT_NULL(get_echo_args(&input));
-}
+// CTEST(echo_utils_test, format_string_test)
+// {
+// 	const char *input = "";
+// 	ASSERT_NOT_NULL(get_echo_args(&input));
+// }
 
-CTEST(echo_utils_test, empty_substr_len_test)
-{
-	const char *input = "";
-	ASSERT_EQUAL(0, get_substr_len(input));
-}
+// CTEST(echo_utils_test, empty_substr_len_test)
+// {
+// 	const char *input = "";
+// 	ASSERT_EQUAL(0, get_substr_len(input));
+// }
 
-CTEST(echo_utils_test, no_pipe_substr_len_test)
-{
-	const char *input = "nopipe";
-	ASSERT_EQUAL(ft_strlen(input), get_substr_len(input));
-}
+// CTEST(echo_utils_test, no_pipe_substr_len_test)
+// {
+// 	const char *input = "nopipe";
+// 	ASSERT_EQUAL(ft_strlen(input), get_substr_len(input));
+// }
 
-CTEST(echo_utils_test, substr_len_test)
-{
-	const char *input = "12345|";
-	ASSERT_EQUAL(5, get_substr_len(input));
-}
+// CTEST(echo_utils_test, substr_len_test)
+// {
+// 	const char *input = "12345|";
+// 	ASSERT_EQUAL(5, get_substr_len(input));
+// }
 
-CTEST(echo_utils_test, substr_zero_len_test)
-{
-	const char *input = "";
-	ASSERT_EQUAL(0, get_substr_len(input));
-}
+// CTEST(echo_utils_test, substr_zero_len_test)
+// {
+// 	const char *input = "";
+// 	ASSERT_EQUAL(0, get_substr_len(input));
+// }
 
-CTEST(echo_utils_test, true_check_quotes)
-{
-	t_check_quotes quotes;
+// CTEST(echo_utils_test, true_check_quotes)
+// {
+// 	t_check_quotes quotes;
 	
-	has_inverted_comma_set("\"appletrreee\"", &quotes);
-	ASSERT_TRUE(quotes.opening);
-	ASSERT_TRUE(quotes.closing);
-}
+// 	has_inverted_comma_set("\"appletrreee\"", &quotes);
+// 	ASSERT_TRUE(quotes.opening);
+// 	ASSERT_TRUE(quotes.closing);
+// }
 
-CTEST(echo_utils_test, only_opening_quotes)
-{
-	t_check_quotes quotes;
+// CTEST(echo_utils_test, only_opening_quotes)
+// {
+// 	t_check_quotes quotes;
 
-	has_inverted_comma_set("\"stringcheese", &quotes);
-	ASSERT_TRUE(quotes.opening);
-	ASSERT_FALSE(quotes.closing);
-}
+// 	has_inverted_comma_set("\"stringcheese", &quotes);
+// 	ASSERT_TRUE(quotes.opening);
+// 	ASSERT_FALSE(quotes.closing);
+// }
 
-CTEST(echo_utils_test, check_no_quotes)
-{
-	t_check_quotes quotes;
+// CTEST(echo_utils_test, check_no_quotes)
+// {
+// 	t_check_quotes quotes;
 
-	has_inverted_comma_set("hala@me", &quotes);
-	ASSERT_FALSE(quotes.opening);
-	ASSERT_FALSE(quotes.closing);
-}
+// 	has_inverted_comma_set("hala@me", &quotes);
+// 	ASSERT_FALSE(quotes.opening);
+// 	ASSERT_FALSE(quotes.closing);
+// }
 
-CTEST(echo_utils_test, format_quotes_string)
-{
-	char **split_splat = format_string_with_quotes("\"look      at me \"now heeeey\"\"");
-	
-	ASSERT_NULL(split_splat[1]);
-	ASSERT_STR("look      at me \"now heeeey", split_splat[0]);
-}
+// CTEST(echo_utils_test, format_quotes_string)
+// {
+// 	char **split_splat = format_string_with_quotes("\"look      at me \"now heeeey\"\"");
 
-CTEST(echo_utils_test, format_no_quotes_string)
-{
-	char *args = "    No     quotes, whitespace    should   be    removed   ";
-	char **formatted_args = format_echo_args(args);
+// 	ASSERT_NULL(split_splat[1]);
+// 	ASSERT_STR("look      at me \"now heeeey", split_splat[0]);
+// }
 
-	ASSERT_STR("No", formatted_args[0]);
-	ASSERT_STR("quotes,", formatted_args[1]);
-	ASSERT_STR("whitespace", formatted_args[2]);
-	ASSERT_STR("should", formatted_args[3]);
-	ASSERT_STR("be", formatted_args[4]);
-	ASSERT_STR("removed", formatted_args[5]);
-	ASSERT_NULL(formatted_args[6]);
-}
+// CTEST(echo_utils_test, format_no_quotes_string)
+// {
+// 	char *args = "    No     quotes, whitespace    should   be    removed   ";
+// 	char **formatted_args = format_echo_args(args);
 
-CTEST(echo_utils_test, echo_w_n_flag)
-{
-	const char *input = "    -n hello";
-	ASSERT_TRUE(parse_n_flag(&input));
-	ASSERT_STR(" hello", input);
-}
+// 	ASSERT_STR("No", formatted_args[0]);
+// 	ASSERT_STR("quotes,", formatted_args[1]);
+// 	ASSERT_STR("whitespace", formatted_args[2]);
+// 	ASSERT_STR("should", formatted_args[3]);
+// 	ASSERT_STR("be", formatted_args[4]);
+// 	ASSERT_STR("removed", formatted_args[5]);
+// 	ASSERT_NULL(formatted_args[6]);
+// }
 
-CTEST(echo_utils_test, echo_w_n_flag_after_quote)
-{
-	const char *input = "   \" -n hello \"";
-	ASSERT_FALSE(parse_n_flag(&input));
-}
+// CTEST(echo_utils_test, echo_w_n_flag)
+// {
+// 	const char *input = "    -n hello";
+// 	ASSERT_TRUE(parse_n_flag(&input));
+// 	ASSERT_STR(" hello", input);
+// }
+
+// CTEST(echo_utils_test, echo_w_n_flag_after_quote)
+// {
+// 	const char *input = "   \" -n hello \"";
+// 	ASSERT_FALSE(parse_n_flag(&input));
+// }
 
 // CTEST(echo_utils_test, format_string_w_quotes_and_whitespace)
 // {
 // 	char *str = "    \"     No     quotes   \"";
-// 	char **m_str = parse_echo(((const char **)(&str)));
+// 	char **m_str = format_echo_args(str);
 
 // 	ASSERT_STR("     No", m_str[0]);
 // 	ASSERT_STR("quotes   ", m_str[1]);
 // 	ASSERT_NULL(m_str[2]);
 // }
+
+// CTEST(echo_utils_test, format_echo_three_strings)
+// {
+// 	char *str = "\"     first string\"       :second str:      \"       third string \"";
+// 	char **m_str = format_echo_args(str);
+
+// 	ASSERT_STR("     first string", m_str[0]);
+// 	ASSERT_STR("string", m_str[1]);
+// 	ASSERT_STR(":second", m_str[2]);
+// 	ASSERT_STR("str:", m_str[2]);
+// 	ASSERT_STR("       third", m_str[3]);
+// 	ASSERT_STR("string", m_str[4]);
+// 	ASSERT_NULL(m_str[5]);
+// }
+

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -2,6 +2,8 @@
 #include "../src/commands/commands.h"
 #include "../libft/libft.h"
 #include <stdio.h>
+#include <string.h>
+#include <strings.h>
 // possible strings
 // (            String with spaces to trim        )
 // (      "string with spaces to trim up to inverted commas"           )
@@ -11,96 +13,148 @@
 // (		whitespace         4 dddaaaaaayyyyyys)
 // (	"	whitespace         4 dddaaaaaayyyyyys, with quotes      ")
 // (	"	quotes with \"\" quotes"      ")
+int size = 4096;
+char buf[4096];
 
-
-void	write_empty_str(const char *string_to_write, int len)
+CTEST_DATA(echo_test)
 {
-	(void)len;
-	ASSERT_STR("\n", string_to_write);
+};
+
+CTEST_SETUP(echo_test)
+{
+	(void)data;
+	bzero(&buf[0], size);
+};
+
+CTEST_TEARDOWN(echo_test)
+{
+	(void)data;
+};
+
+void	write_to_buf(const char *string_to_write, int len)
+{
+	strncpy(&buf[0], string_to_write, len);
 }
 
-CTEST(echo_test, empty_str)
+CTEST2(echo_test, empty_str)
 {
+	(void)data;
 	const char *input = "";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_empty_str));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("\n", &buf[0]);
 }
 
-void	write_str_without_quotes(const char *string_to_write, int len)
+CTEST2(echo_test, simple_str_without_quotes)
 {
-	(void)len;
-	ASSERT_STR("simple test string\n", string_to_write);
-}
-
-CTEST(echo_test, simple_str_without_quotes)
-{
+	(void)data;
 	const char *input = "simple test string";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_str_without_quotes));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("simple test string\n", &buf[0]);
 }
 
-void	write_2_strs_without_and_with_quotes(const char *string_to_write, int len)
+CTEST2(echo_test, write_2_strs_without_and_with_quotes)
 {
-	(void)len;
-	const char *str = {"first string trimmed      second string not trimmed\n"};
-	ASSERT_STR(str, string_to_write);
-}
-
-CTEST(echo_test, write_2_strs_without_and_with_quotes)
-{
+	(void)data;
 	const char *input = "     first string trimmed \"     second string not trimmed\"";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_2_strs_without_and_with_quotes));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("first string trimmed      second string not trimmed\n", &buf[0]);
 }
 
-void	write_2_strs_without_trimmed_and_with_quotes(const char *string_to_write, int len)
+CTEST2(echo_test, write_2_strs_without_trimmed_and_with_quotes)
 {
-	(void)len;
-	const char *str = {"first string trimmed      second string not trimmed\n"};
-	ASSERT_STR(str, string_to_write);
-}
-
-CTEST(echo_test, write_2_strs_without_trimmed_and_with_quotes)
-{
+	(void)data;
 	const char *input = "     first           string             trimmed \"     second string not trimmed\"";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_2_strs_without_trimmed_and_with_quotes));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("first string trimmed      second string not trimmed\n", &buf[0]);
 }
 
-void	write_2_strs_with_and_without_quotes_trimmed(const char *string_to_write, int len)
+CTEST2(echo_test, write_2_strs_with_and_without_quotes_trimmed)
 {
-	(void)len;
-	const char *str = {"     first           string second string trimmed\n"};
-	ASSERT_STR(str, string_to_write);
-}
-
-CTEST(echo_test, write_2_strs_with_and_without_quotes_trimmed)
-{
+	(void)data;
 	const char *input = "\"     first           string\"      second      string        trimmed";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_2_strs_with_and_without_quotes_trimmed));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("     first           string second string trimmed\n", &buf[0]);
 }
 
-void	write_4_strs_with_and_without_quotes_trimmed(const char *string_to_write, int len)
+CTEST2(echo_test, write_4_strs_with_and_without_quotes_trimmed)
 {
-	(void)len;
-	const char *str = {"   First   string  N  O  T  trimmed !\n"};
-	ASSERT_STR(str, string_to_write);
-}
-
-CTEST(echo_test, write_4_strs_with_and_without_quotes_trimmed)
-{
+	(void)data;
 	const char *input = "\"   First  \"      string  \" N  O  T  trimmed\"      !";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_4_strs_with_and_without_quotes_trimmed));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("   First   string  N  O  T  trimmed !\n", &buf[0]);
 }
 
-void	write_strs_with_and_without_quotes_n_flag(const char *string_to_write, int len)
+CTEST2(echo_test, write_strs_with_and_without_quotes_n_flag)
 {
-	(void)len;
-	const char *str = {"   First   string  N  O  T  trimmed !"};
-	ASSERT_STR(str, string_to_write);
-}
-
-CTEST(echo_test, write_strs_with_and_without_quotes_n_flag)
-{
+	(void)data;
 	const char *input = "-n \"   First  \"      string  \" N  O  T  trimmed\"      !";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_strs_with_and_without_quotes_n_flag));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("   First   string  N  O  T  trimmed !", &buf[0]);
 }
+
+CTEST2(echo_test, write_strs_with_missing_quote_and_without_quotes)
+{
+	(void)data;
+	const char *input = "\"   First  string  \"        trimmed\"      !";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("   First  string   trimmed!\n", &buf[0]);
+}
+
+CTEST2(echo_test, write_str_missing_closing_quote)
+{
+	(void)data;
+	const char *input = "\"   First  string         trimmed      !";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("First string trimmed !\n", &buf[0]);
+}
+
+CTEST2(echo_test, write_str_missing_closing_quote_at_the_end)
+{
+	(void)data;
+	const char *input = "   First  string         trimmed      !\"";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("First string trimmed !\n", &buf[0]);
+}
+
+CTEST2(echo_test, write_str_double_quote_in_the_middle)
+{
+	(void)data;
+	const char *input = "   First  string   \"      trimmed      !";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("First string trimmed !\n", &buf[0]);
+}
+
+CTEST2(echo_test, write_two_empty_strings)
+{
+	(void)data;
+	const char *input = "\"\"\"\"";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("\n", &buf[0]);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 // CTEST(echo_utils_test, empty_substr_len_test)

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -16,7 +16,7 @@
 void	write_empty_str(const char *string_to_write, int len)
 {
 	(void)len;
-	ASSERT_STR("", string_to_write);
+	ASSERT_STR("\n", string_to_write);
 }
 
 CTEST(echo_test, empty_str)
@@ -28,7 +28,7 @@ CTEST(echo_test, empty_str)
 void	write_str_without_quotes(const char *string_to_write, int len)
 {
 	(void)len;
-	ASSERT_STR("simple test string", string_to_write);
+	ASSERT_STR("simple test string\n", string_to_write);
 }
 
 CTEST(echo_test, simple_str_without_quotes)
@@ -40,7 +40,7 @@ CTEST(echo_test, simple_str_without_quotes)
 void	write_2_strs_without_and_with_quotes(const char *string_to_write, int len)
 {
 	(void)len;
-	const char *str = {"first string trimmed      second string not trimmed"};
+	const char *str = {"first string trimmed      second string not trimmed\n"};
 	ASSERT_STR(str, string_to_write);
 }
 
@@ -49,6 +49,59 @@ CTEST(echo_test, write_2_strs_without_and_with_quotes)
 	const char *input = "     first string trimmed \"     second string not trimmed\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_2_strs_without_and_with_quotes));
 }
+
+void	write_2_strs_without_trimmed_and_with_quotes(const char *string_to_write, int len)
+{
+	(void)len;
+	const char *str = {"first string trimmed      second string not trimmed\n"};
+	ASSERT_STR(str, string_to_write);
+}
+
+CTEST(echo_test, write_2_strs_without_trimmed_and_with_quotes)
+{
+	const char *input = "     first           string             trimmed \"     second string not trimmed\"";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_2_strs_without_trimmed_and_with_quotes));
+}
+
+void	write_2_strs_with_and_without_quotes_trimmed(const char *string_to_write, int len)
+{
+	(void)len;
+	const char *str = {"     first           string second string trimmed\n"};
+	ASSERT_STR(str, string_to_write);
+}
+
+CTEST(echo_test, write_2_strs_with_and_without_quotes_trimmed)
+{
+	const char *input = "\"     first           string\"      second      string        trimmed";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_2_strs_with_and_without_quotes_trimmed));
+}
+
+void	write_4_strs_with_and_without_quotes_trimmed(const char *string_to_write, int len)
+{
+	(void)len;
+	const char *str = {"   First   string  N  O  T  trimmed !\n"};
+	ASSERT_STR(str, string_to_write);
+}
+
+CTEST(echo_test, write_4_strs_with_and_without_quotes_trimmed)
+{
+	const char *input = "\"   First  \"      string  \" N  O  T  trimmed\"      !";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_4_strs_with_and_without_quotes_trimmed));
+}
+
+void	write_strs_with_and_without_quotes_n_flag(const char *string_to_write, int len)
+{
+	(void)len;
+	const char *str = {"   First   string  N  O  T  trimmed !"};
+	ASSERT_STR(str, string_to_write);
+}
+
+CTEST(echo_test, write_strs_with_and_without_quotes_n_flag)
+{
+	const char *input = "-n \"   First  \"      string  \" N  O  T  trimmed\"      !";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_strs_with_and_without_quotes_n_flag));
+}
+
 
 // CTEST(echo_utils_test, empty_substr_len_test)
 // {

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -1,7 +1,7 @@
 #include "ctest.h"
 #include "../src/commands/commands.h"
 #include "../libft/libft.h"
-
+#include <stdio.h>
 // possible strings
 // (            String with spaces to trim        )
 // (      "string with spaces to trim up to inverted commas"           )
@@ -12,10 +12,19 @@
 // (	"	whitespace         4 dddaaaaaayyyyyys, with quotes      ")
 // (	"	quotes with \"\" quotes"      ")
 
+void	fake_output(const char **strings_to_write)
+{
+	for (int i = 0; strings_to_write[i] != NULL; ++i)
+	{
+		printf(strings_to_write[i]);
+		printf(" ");
+	}
+}
+
 CTEST(echo_test, returns_true_with_emptry_str_input)
 {
 	const char *input = "";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, fake_output));
 }
 
 // CTEST(echo_utils_test, empty_substr_len_test)

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -91,7 +91,7 @@ CTEST2(echo_test, write_strs_with_and_without_quotes_n_flag)
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
 	ASSERT_STR("   First   string  N  O  T  trimmed !", &buf[0]);
 }
-
+      
 CTEST2(echo_test, write_strs_with_missing_quote_and_without_quotes)
 {
 	(void)data;
@@ -124,34 +124,13 @@ CTEST2(echo_test, write_str_double_quote_in_the_middle)
 	ASSERT_STR("First string trimmed !\n", &buf[0]);
 }
 
-CTEST2(echo_test, write_two_empty_strings)
+CTEST2_SKIP(echo_test, write_two_empty_strings)
 {
 	(void)data;
-	const char *input = "\"\"\"\"";
+	const char *input = "    \"\"\"\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
 	ASSERT_STR("\n", &buf[0]);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -124,17 +124,13 @@ CTEST2(echo_test, write_str_double_quote_in_the_middle)
 	ASSERT_STR("First string trimmed !\n", &buf[0]);
 }
 
-CTEST2_SKIP(echo_test, write_two_empty_strings)
+CTEST2(echo_test, write_two_empty_strings)
 {
 	(void)data;
 	const char *input = "    \"\"\"\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
 	ASSERT_STR("\n", &buf[0]);
 }
-
-
-
-
 
 // CTEST(echo_utils_test, empty_substr_len_test)
 // {

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -12,15 +12,42 @@
 // (	"	whitespace         4 dddaaaaaayyyyyys, with quotes      ")
 // (	"	quotes with \"\" quotes"      ")
 
-void	fake_output(const char *string_to_write)
+
+void	write_empty_str(const char *string_to_write, int len)
 {
+	(void)len;
 	ASSERT_STR("", string_to_write);
 }
 
-CTEST(echo_test, returns_true_with_emptry_str_input)
+CTEST(echo_test, empty_str)
 {
 	const char *input = "";
-	ASSERT_EQUAL(SUCCESS, echo_command(&input, fake_output));
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_empty_str));
+}
+
+void	write_str_without_quotes(const char *string_to_write, int len)
+{
+	(void)len;
+	ASSERT_STR("simple test string", string_to_write);
+}
+
+CTEST(echo_test, simple_str_without_quotes)
+{
+	const char *input = "simple test string";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_str_without_quotes));
+}
+
+void	write_2_strs_without_and_with_quotes(const char *string_to_write, int len)
+{
+	(void)len;
+	const char *str = {"first string trimmed      second string not trimmed"};
+	ASSERT_STR(str, string_to_write);
+}
+
+CTEST(echo_test, write_2_strs_without_and_with_quotes)
+{
+	const char *input = "     first string trimmed \"     second string not trimmed\"";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_2_strs_without_and_with_quotes));
 }
 
 // CTEST(echo_utils_test, empty_substr_len_test)
@@ -51,7 +78,7 @@ CTEST(echo_test, returns_true_with_emptry_str_input)
 // {
 // 	t_check_quotes quotes;
 	
-// 	has_inverted_comma_set("\"appletrreee\"", &quotes);
+// 	has_double_quotes_set("\"appletrreee\"", &quotes);
 // 	ASSERT_TRUE(quotes.opening);
 // 	ASSERT_TRUE(quotes.closing);
 // }
@@ -60,7 +87,7 @@ CTEST(echo_test, returns_true_with_emptry_str_input)
 // {
 // 	t_check_quotes quotes;
 
-// 	has_inverted_comma_set("\"stringcheese", &quotes);
+// 	has_double_quotes_set("\"stringcheese", &quotes);
 // 	ASSERT_TRUE(quotes.opening);
 // 	ASSERT_FALSE(quotes.closing);
 // }
@@ -69,7 +96,7 @@ CTEST(echo_test, returns_true_with_emptry_str_input)
 // {
 // 	t_check_quotes quotes;
 
-// 	has_inverted_comma_set("hala@me", &quotes);
+// 	has_double_quotes_set("hala@me", &quotes);
 // 	ASSERT_FALSE(quotes.opening);
 // 	ASSERT_FALSE(quotes.closing);
 // }

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -13,6 +13,7 @@
 // (		whitespace         4 dddaaaaaayyyyyys)
 // (	"	whitespace         4 dddaaaaaayyyyyys, with quotes      ")
 // (	"	quotes with \"\" quotes"      ")
+
 int size = 4096;
 char buf[4096];
 
@@ -132,113 +133,26 @@ CTEST2(echo_test, write_two_empty_strings)
 	ASSERT_STR("\n", &buf[0]);
 }
 
-// CTEST(echo_utils_test, empty_substr_len_test)
-// {
-// 	const char *input = "";
-// 	ASSERT_EQUAL(0, get_substr_len(input));
-// }
+CTEST2(echo_test, write_two_strs_without_space_in_between)
+{
+	(void)data;
+	const char *input = "hello\"you\"";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("helloyou\n", &buf[0]);
+}
 
-// CTEST(echo_utils_test, no_pipe_substr_len_test)
-// {
-// 	const char *input = "nopipe";
-// 	ASSERT_EQUAL(ft_strlen(input), get_substr_len(input));
-// }
+CTEST2(echo_test, write_two_strs_with_space_in_between)
+{
+	(void)data;
+	const char *input = "hello \"you\"";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("hello you\n", &buf[0]);
+}
 
-// CTEST(echo_utils_test, substr_len_test)
-// {
-// 	const char *input = "12345|";
-// 	ASSERT_EQUAL(5, get_substr_len(input));
-// }
-
-// CTEST(echo_utils_test, substr_zero_len_test)
-// {
-// 	const char *input = "";
-// 	ASSERT_EQUAL(0, get_substr_len(input));
-// }
-
-// CTEST(echo_utils_test, true_check_quotes)
-// {
-// 	t_check_quotes quotes;
-	
-// 	has_double_quotes_set("\"appletrreee\"", &quotes);
-// 	ASSERT_TRUE(quotes.opening);
-// 	ASSERT_TRUE(quotes.closing);
-// }
-
-// CTEST(echo_utils_test, only_opening_quotes)
-// {
-// 	t_check_quotes quotes;
-
-// 	has_double_quotes_set("\"stringcheese", &quotes);
-// 	ASSERT_TRUE(quotes.opening);
-// 	ASSERT_FALSE(quotes.closing);
-// }
-
-// CTEST(echo_utils_test, check_no_quotes)
-// {
-// 	t_check_quotes quotes;
-
-// 	has_double_quotes_set("hala@me", &quotes);
-// 	ASSERT_FALSE(quotes.opening);
-// 	ASSERT_FALSE(quotes.closing);
-// }
-
-// CTEST(echo_utils_test, format_quotes_string)
-// {
-// 	char **split_splat = format_string_with_quotes("\"look      at me \"now heeeey\"\"");
-
-// 	ASSERT_NULL(split_splat[1]);
-// 	ASSERT_STR("look      at me \"now heeeey", split_splat[0]);
-// }
-
-// CTEST(echo_utils_test, format_no_quotes_string)
-// {
-// 	char *args = "    No     quotes, whitespace    should   be    removed   ";
-// 	char **formatted_args = format_echo_args(args);
-
-// 	ASSERT_STR("No", formatted_args[0]);
-// 	ASSERT_STR("quotes,", formatted_args[1]);
-// 	ASSERT_STR("whitespace", formatted_args[2]);
-// 	ASSERT_STR("should", formatted_args[3]);
-// 	ASSERT_STR("be", formatted_args[4]);
-// 	ASSERT_STR("removed", formatted_args[5]);
-// 	ASSERT_NULL(formatted_args[6]);
-// }
-
-// CTEST(echo_utils_test, echo_w_n_flag)
-// {
-// 	const char *input = "    -n hello";
-// 	ASSERT_TRUE(parse_n_flag(&input));
-// 	ASSERT_STR(" hello", input);
-// }
-
-// CTEST(echo_utils_test, echo_w_n_flag_after_quote)
-// {
-// 	const char *input = "   \" -n hello \"";
-// 	ASSERT_FALSE(parse_n_flag(&input));
-// }
-
-// CTEST(echo_utils_test, format_string_w_quotes_and_whitespace)
-// {
-// 	char *str = "    \"     No     quotes   \"";
-// 	char **m_str = format_echo_args(str);
-
-// 	ASSERT_STR("     No", m_str[0]);
-// 	ASSERT_STR("quotes   ", m_str[1]);
-// 	ASSERT_NULL(m_str[2]);
-// }
-
-// CTEST(echo_utils_test, format_echo_three_strings)
-// {
-// 	char *str = "\"     first string\"       :second str:      \"       third string \"";
-// 	char **m_str = format_echo_args(str);
-
-// 	ASSERT_STR("     first string", m_str[0]);
-// 	ASSERT_STR("string", m_str[1]);
-// 	ASSERT_STR(":second", m_str[2]);
-// 	ASSERT_STR("str:", m_str[2]);
-// 	ASSERT_STR("       third", m_str[3]);
-// 	ASSERT_STR("string", m_str[4]);
-// 	ASSERT_NULL(m_str[5]);
-// }
-
+CTEST2(echo_test, write_two_strs_with_space_in_between_2)
+{
+	(void)data;
+	const char *input = "hello\" you\"";
+	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	ASSERT_STR("hello you\n", &buf[0]);
+}


### PR DESCRIPTION
- Changed the signature of echo_command to receive a function pointer:
      ` int echo_command(const char **input, t_output_stdout output)`
        now in production we can output the string on stdout and for testing purposes we write to a buffer to be compared with the 
        expected output.
- Removed all the mallocs (ft_split, ft_strtrim)
       the n flags stays the same.
       Now in the beginning of echo command we allocate a str the same size of input, which is our worst case scenario.
       After that we go through the input searching for quoted strings and just ft_strncpy them.
       For unquoted strings we trim the extra spaces and, if the extra spaces are between two words, we add only one space.
       We copy all the strings like:
              `BestShellEver: echo     WHITESPACES           hello  "  WHITESPACES    you"          !  WHITESPACES  !  WHITESPACES  !  WHITESPACES  !`
       becomes:
               `stdout_buffer = "hello        you  ! ! ! !\n"`
       and the function pointer will just print the whole string.
       this way we only malloc once.

- Removed tests targeting functions that are used just internally and wont be visible from outside. For echo command, at the moment, makes more sense to test just the high level function and check if the output is correct, we may need to add other tests in the future as it grows, but this way is easier to refactor and make changes in the functions without having to change the tests.

- file commands.h should have only the high level functions prototype (exit_command, echo_command, pdw ...), all the others we keep in separate headers so they are not visible for those who include the commands.h.

