### PR TITLE
Unknown command message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ TEST_FILES=					\
 	tests/dispatch_test.c	\
 	tests/echo_test.c	\
 	tests/pwd_test.c	\
+	tests/unknown_test.c	\
 
 MINISHELL_OBJS=$(MINISHELL_src:.c=.o)
 

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -11,7 +11,7 @@ typedef enum e_special_chars
 	NULL_TERMINATOR = '\0'
 }	t_special_chars;
 
-typedef void	(*t_output_stdout)(const char *, int);
+typedef void	(*t_output_stdout)(const char *);
 
 void	exit_command(t_exit_code exit_code);
 int		echo_command(const char **input, t_output_stdout output);

--- a/src/commands/echo_command.c
+++ b/src/commands/echo_command.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
-#include <ctype.h> 
+#include <ctype.h>
 #include <libft.h>
 #include <parser/parser.h>
 #include <commands/echo_utils.h>
@@ -53,7 +53,7 @@ static void	get_str_with_quotes(const char **input,
 
 	if (quotes.start && quotes.end)
 	{
-		strncpy(&stdout_buffer[*buffer_index], quotes.start, size);
+		ft_memcpy(&stdout_buffer[*buffer_index], quotes.start, size);
 		*input += size + num_quotes;
 		*buffer_index += size;
 		add_space_between_strs(*(*input), stdout_buffer, buffer_index);
@@ -65,9 +65,9 @@ static void	get_str_with_quotes(const char **input,
 static int	handle_empty_str(t_bool has_n_flag, t_output_stdout output)
 {
 	if (has_n_flag)
-		output("", 1);
+		output("");
 	else
-		output("\n", 1);
+		output("\n");
 	return (SUCCESS);
 }
 
@@ -91,8 +91,7 @@ int	echo_command(const char **input, t_output_stdout output)
 	}
 	if (has_n_flag)
 		stdout_buffer[buffer_index] = '\0';
-	++buffer_index;
-	output(stdout_buffer, buffer_index);
+	output(stdout_buffer);
 	free(stdout_buffer);
 	return (SUCCESS);
 }

--- a/src/commands/echo_utils.c
+++ b/src/commands/echo_utils.c
@@ -37,9 +37,11 @@ t_bool	parse_n_flag(const char **input)
 	return (FALSE);
 }
 
-void	write_to_stdout(const char *string_to_write, int len)
+void	write_to_stdout(const char *string_to_write)
 {
-	write(STDOUT_FILENO, string_to_write, len);
+	const int len_inside = ft_strlen(string_to_write);
+
+	write(STDOUT_FILENO, string_to_write, len_inside);
 }
 
 void	trim_extra_spaces_between_words(const char **input,

--- a/src/commands/echo_utils.c
+++ b/src/commands/echo_utils.c
@@ -39,7 +39,7 @@ t_bool	parse_n_flag(const char **input)
 
 void	write_to_stdout(const char *string_to_write)
 {
-	const int len_inside = ft_strlen(string_to_write);
+	const int	len_inside = ft_strlen(string_to_write);
 
 	write(STDOUT_FILENO, string_to_write, len_inside);
 }

--- a/src/commands/echo_utils.h
+++ b/src/commands/echo_utils.h
@@ -3,7 +3,7 @@
 # include <defines.h>
 
 t_bool				parse_n_flag(const char **input);
-void				write_to_stdout(const char *string_to_write, int len);
+void				write_to_stdout(const char *string_to_write);
 void				trim_extra_spaces_between_words(const char **input,
 						char *stdout_buffer,
 						int *buffer_index);

--- a/src/commands/pwd_command.c
+++ b/src/commands/pwd_command.c
@@ -11,6 +11,6 @@ int	pwd_command(t_output_stdout output)
 	getcwd(&buffer[0], sizeof(buffer));
 	len = ft_strlen(buffer);
 	buffer[len] = '\n';
-	output(&buffer[0], len + 1);
+	output(&buffer[0]);
 	return (SUCCESS);
 }

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -22,7 +22,7 @@ static void	copy_unknown_command_to_buffer(const char **input, char buffer[])
 	buffer[i] = '\0';
 }
 
-void	unknown_command(const char **input, t_output_stdout output)
+t_bool	unknown_command(const char **input, t_output_stdout output)
 {
 	const char	*shell_name = "BestShellEver: ";
 	const char	*command_not_found = ": command not found\n";
@@ -33,6 +33,7 @@ void	unknown_command(const char **input, t_output_stdout output)
 	output(shell_name);
 	output(&unknown_command_str[0]);
 	output(command_not_found);
+	return (FALSE);
 }
 
 t_bool	dispatch_commands(const char **input, t_command command)
@@ -43,7 +44,9 @@ t_bool	dispatch_commands(const char **input, t_command command)
 		return (echo_command(input, write_to_stdout));
 	else if (command == PWD)
 		return (pwd_command(write_to_stdout));
-	else
-		unknown_command(input, write_to_stdout);
+	else if (command == INVALID)
+		return (unknown_command(input, write_to_stdout));
+	else if (command == EMPTY_LINE)
+		return (TRUE);
 	return (FALSE);
 }

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -8,7 +8,7 @@
 
 static void	copy_unknown_command_to_buffer(const char **input, char buffer[])
 {
-	int i;
+	int	i;
 
 	i = 0;
 	while ((*input)[i] && !isspace((*input)[i]))

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -8,13 +8,16 @@
 
 static void	copy_unknown_command_to_buffer(const char **input, char buffer[])
 {
-	int	i;
+	char	cur;
+	int		i;
 
 	i = 0;
-	while ((*input)[i] && !isspace((*input)[i]))
+	cur = (*input)[i];
+	while (cur && !isspace(cur))
 	{
-		buffer[i] = (*input)[i];
+		buffer[i] = cur;
 		++i;
+		cur = (*input)[i];
 	}
 	buffer[i] = '\0';
 }

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -1,16 +1,46 @@
 #include <parser/dispatcher.h>
 #include <commands/commands.h>
 #include <commands/echo_utils.h>
+#include <parser/parser.h>
 #include <stdio.h>
+#include <libft.h>
+#include <ctype.h>
+
+static void	copy_unknown_command_to_buffer(const char **input, char buffer[])
+{
+	int i;
+
+	i = 0;
+	while ((*input)[i] && !isspace((*input)[i]))
+	{
+		buffer[i] = (*input)[i];
+		++i;
+	}
+	buffer[i] = '\0';
+}
+
+void	unknown_command(const char **input, t_output_stdout output)
+{
+	const char	*shell_name = "BestShellEver: ";
+	const char	*command_not_found = ": command not found\n";
+	char		unknown_command_str[4096];
+
+	skip_spaces(input);
+	copy_unknown_command_to_buffer(input, &unknown_command_str[0]);
+	output(shell_name);
+	output(&unknown_command_str[0]);
+	output(command_not_found);
+}
 
 t_bool	dispatch_commands(const char **input, t_command command)
 {
-	(void)input;
 	if (command == EXIT)
 		exit_command(SUCCESS);
 	else if (command == ECHO)
 		return (echo_command(input, write_to_stdout));
 	else if (command == PWD)
 		return (pwd_command(write_to_stdout));
+	else
+		unknown_command(input, write_to_stdout);
 	return (FALSE);
 }

--- a/src/parser/dispatcher.h
+++ b/src/parser/dispatcher.h
@@ -1,7 +1,9 @@
 #ifndef DISPATCHER_H
 # define DISPATCHER_H
 # include <defines.h>
+# include <commands/commands.h>
 
+void	unknown_command(const char **input, t_output_stdout output);
 t_bool	dispatch_commands(const char **input, t_command command);
 
 #endif

--- a/src/parser/dispatcher.h
+++ b/src/parser/dispatcher.h
@@ -3,7 +3,7 @@
 # include <defines.h>
 # include <commands/commands.h>
 
-void	unknown_command(const char **input, t_output_stdout output);
+t_bool	unknown_command(const char **input, t_output_stdout output);
 t_bool	dispatch_commands(const char **input, t_command command);
 
 #endif

--- a/tests/dispatch_test.c
+++ b/tests/dispatch_test.c
@@ -6,3 +6,9 @@ CTEST(dispatch_test, echo_true)
 	const char *input = "echo";
 	ASSERT_EQUAL(SUCCESS, dispatch_commands(&input, ECHO));
 }
+
+CTEST(dispatch_test, unknown_command)
+{
+	const char *input = "dnjekndwejk";
+	ASSERT_EQUAL(SUCCESS, dispatch_commands(&input, INVALID));
+}

--- a/tests/dispatch_test.c
+++ b/tests/dispatch_test.c
@@ -1,12 +1,6 @@
 #include "ctest.h"
 #include "../src/parser/dispatcher.h"
 
-CTEST(dispatch_test, returns_false)
-{
-	const char *input = "exit";
-	ASSERT_FALSE(dispatch_commands(&input, 3));
-}
-
 CTEST(dispatch_test, echo_true)
 {
 	const char *input = "echo";

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -32,8 +32,10 @@ CTEST_TEARDOWN(echo_test)
 	(void)data;
 };
 
-void	write_to_buf(const char *string_to_write, int len)
+void	write_to_buf(const char *string_to_write)
 {
+	const int len = strlen(string_to_write);
+
 	strncpy(&buf[0], string_to_write, len);
 }
 
@@ -57,8 +59,11 @@ CTEST2(echo_test, write_2_strs_without_and_with_quotes)
 {
 	(void)data;
 	const char *input = "     first string trimmed \"     second string not trimmed\"";
+	const char *expected = "first string trimmed      second string not trimmed\n";
+	const int expected_len = strlen(expected);
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
-	ASSERT_STR("first string trimmed      second string not trimmed\n", &buf[0]);
+	ASSERT_STR(expected, &buf[0]);
+	ASSERT_EQUAL(expected_len, strlen(&buf[0]));
 }
 
 CTEST2(echo_test, write_2_strs_without_trimmed_and_with_quotes)
@@ -66,6 +71,7 @@ CTEST2(echo_test, write_2_strs_without_trimmed_and_with_quotes)
 	(void)data;
 	const char *input = "     first           string             trimmed \"     second string not trimmed\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	
 	ASSERT_STR("first string trimmed      second string not trimmed\n", &buf[0]);
 }
 
@@ -106,6 +112,7 @@ CTEST2(echo_test, write_str_missing_closing_quote)
 	(void)data;
 	const char *input = "\"   First  string         trimmed      !";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("First string trimmed !\n", &buf[0]);
 }
 
@@ -114,6 +121,7 @@ CTEST2(echo_test, write_str_missing_closing_quote_at_the_end)
 	(void)data;
 	const char *input = "   First  string         trimmed      !\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("First string trimmed !\n", &buf[0]);
 }
 
@@ -138,6 +146,7 @@ CTEST2(echo_test, write_two_strs_without_space_in_between)
 	(void)data;
 	const char *input = "hello\"you\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("helloyou\n", &buf[0]);
 }
 
@@ -146,6 +155,7 @@ CTEST2(echo_test, write_two_strs_with_space_in_between)
 	(void)data;
 	const char *input = "hello \"you\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("hello you\n", &buf[0]);
 }
 
@@ -154,6 +164,7 @@ CTEST2(echo_test, write_two_strs_with_space_in_between_2)
 	(void)data;
 	const char *input = "hello\" you\"";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("hello you\n", &buf[0]);
 }
 
@@ -162,6 +173,7 @@ CTEST2(echo_test, mmultiple_n_flags_with_spaces)
 	(void)data;
 	const char *input = "-n -n hello you";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("hello you", &buf[0]);
 }
 
@@ -170,6 +182,7 @@ CTEST2(echo_test, multiple_n_flags_with_no_spacing)
 	(void)data;
 	const char *input = "-n-n-n-n hello you";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("-n-n-n-n hello you\n", &buf[0]);
 }
 
@@ -179,6 +192,7 @@ CTEST2(echo_test, n_flag_with_multiple_ns)
 	(void)data;
 	const char *input = "-nnnnnnn hello you";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+	
 	ASSERT_STR("hello you", &buf[0]);
 }
 
@@ -187,6 +201,7 @@ CTEST2(echo_test, n_flag_with_multiple_ns_invalid)
 	(void)data;
 	const char *input = "-nnnnnnn-n hello you";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("-nnnnnnn-n hello you\n", &buf[0]);
 }
 
@@ -195,5 +210,6 @@ CTEST2(echo_test, n_flag_with_multiple_ns_valid)
 	(void)data;
 	const char *input = "-nnnnnnn -n hello you";
 	ASSERT_EQUAL(SUCCESS, echo_command(&input, write_to_buf));
+
 	ASSERT_STR("hello you", &buf[0]);
 }

--- a/tests/parser_test.c
+++ b/tests/parser_test.c
@@ -11,7 +11,7 @@ CTEST(parse_input, no_line_to_parse)
     ASSERT_FALSE(parse_input(NULL));
 }
 
-CTEST(parse_command, invalid_command)
+CTEST(parse_command, unknown_command)
 {
     const char *input = "ecth";
     ASSERT_EQUAL(INVALID, parse_command(&input));

--- a/tests/pwd_test.c
+++ b/tests/pwd_test.c
@@ -24,8 +24,10 @@ CTEST_TEARDOWN(pwd_test)
 	(void)data;
 };
 
-void	write_to_buf1(const char *string_to_write, int len)
+void	write_to_buf1(const char *string_to_write)
 {
+	const int len = strlen(string_to_write);
+
 	strncpy(&buf1[0], string_to_write, len);
 }
 

--- a/tests/unknown_test.c
+++ b/tests/unknown_test.c
@@ -1,0 +1,59 @@
+#include "ctest.h"
+#include "../src/commands/commands.h"
+#include "../src/parser/dispatcher.h"
+#include "../libft/libft.h"
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+
+int size2 = 4096;
+char buf_1[4096];
+char buf_2[4096];
+char buf_3[4096];
+
+CTEST_DATA(unkown_command_test)
+{
+};
+
+CTEST_SETUP(unkown_command_test)
+{
+	(void)data;
+	bzero(&buf_1[0], size2);
+	bzero(&buf_2[0], size2);
+	bzero(&buf_3[0], size2);
+};
+
+CTEST_TEARDOWN(unkown_command_test)
+{
+	(void)data;
+};
+
+void	write_to_buf2(const char *string_to_write)
+{
+	const int len = strlen(string_to_write);
+	static int i = 1;
+	switch (i)
+	{
+	case 1:
+		strncpy(&buf_1[0], string_to_write, len);
+		break;
+	case 2:
+		strncpy(&buf_2[0], string_to_write, len);
+		break;
+	case 3:
+		strncpy(&buf_3[0], string_to_write, len);
+		break;
+	}
+	++i;
+}
+
+CTEST2(unkown_command_test, success)
+{
+	(void)data;
+    const char *expected[3] = {"BestShellEver: ", "blah", ": command not found\n"};
+	const char *input = "blah diedioweopdjeiowjdoijewoi";
+	unknown_command(&input, write_to_buf2);
+	ASSERT_STR(expected[0], &buf_1[0]);
+	ASSERT_STR(expected[1], &buf_2[0]);
+	ASSERT_STR(expected[2], &buf_3[0]);
+}


### PR DESCRIPTION
- Removed arg len from t_output_stdout function, I think it makes more sense to compute the length inside the function. So write_to_stdout() signature changed and also the tests.
- I was using strncpy() to copy quoted strings, we don't have a ft_strncpy and ft_strlcpy doesn't work as expected in this case, so I decided to use ft_memcpy().
- In pwd_command() the only change is that output doesn't receive len anymore.
- Unknown_command(): When we give a line like: ` hwuhduwei duehudeh dwjeidj ` to bash it outputs: `Bash: hwuhduwei: command not found`.
         - So I'm doing the same, if we provide a line that doesn't   start with a valid command, it will output `BestShellEver: <the first string of the input>: command not found`.
- Added command == EMPTY_LINE to dispatcher: Just gives the prompt back.
-  