### PR TITLE
Get executable path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MINISHELL_INCS= 						\
 	src/parser/parser.h					\
 	src/output/prompt.h					\
 	src/parser/dispatcher.h				\
+	src/parser/get_executable_path.h	\
 	src/commands/commands.h				\
 	src/commands/echo_utils.h			\
 	src/commands/echo_handle_quotes.h	\
@@ -20,19 +21,21 @@ MINISHELL_src= 							\
 	src/output/prompt.c					\
 	src/parser/parser_utils.c			\
 	src/parser/dispatcher.c				\
+	src/parser/get_executable_path.c	\
 	src/commands/exit_command.c			\
 	src/commands/echo_command.c			\
 	src/commands/pwd_command.c			\
 	src/commands/echo_utils.c			\
 	src/commands/echo_handle_quotes.c	\
 
-TEST_FILES=					\
-	tests/main.c 			\
-	tests/parser_test.c		\
-	tests/dispatch_test.c	\
-	tests/echo_test.c	\
-	tests/pwd_test.c	\
-	tests/unknown_test.c	\
+TEST_FILES=								\
+	tests/main.c 						\
+	tests/parser_test.c					\
+	tests/dispatch_test.c				\
+	tests/echo_test.c					\
+	tests/pwd_test.c					\
+	tests/unknown_test.c				\
+	tests/get_executable_path_test.c	\
 
 MINISHELL_OBJS=$(MINISHELL_src:.c=.o)
 

--- a/src/parser/get_executable_path.c
+++ b/src/parser/get_executable_path.c
@@ -22,7 +22,8 @@ static int	get_sub_path_len(const char *path)
 	return (i);
 }
 
-static void	copy_possible_path_to_buffer(const char *all_paths, char *buffer, int size)
+static void	copy_possible_path_to_buffer(const char *all_paths,
+		char *buffer, int size)
 {
 	ft_strlcpy(buffer, all_paths, size + TERMINATOR);
 }

--- a/src/parser/get_executable_path.c
+++ b/src/parser/get_executable_path.c
@@ -1,0 +1,35 @@
+#include <libft.h>
+#include <sys/stat.h>
+#include <stdio.h>
+
+/*
+	command format for now = "/ls", including the backslash
+	probably gonna need to strjoin that on there.
+
+	getenv(=PATH) returns a string like this: "/bin;usr/bin;usr/sbin;/sbin"
+
+	which is then split on colons
+	I loop through each seperated path to see if it can be accessed with stat() which returns 0 on success otherwise -1
+*/
+
+char	*get_executable_path(const char *command)
+{
+	const char	**all_paths = (const char **)ft_split(getenv("PATH="), ':');
+	char		*executable_path;
+	int			i;
+	struct	stat	buf;
+
+	if (!command)
+		return (NULL);
+	i = 0;
+	executable_path = NULL;
+	while (all_paths[i])
+	{
+		executable_path = ft_strjoin(all_paths[i], command);
+		if (executable_path && stat(executable_path, &buf) == 0)
+			return (executable_path);
+		free(executable_path);
+		i++;
+	}
+	return (NULL);
+}

--- a/src/parser/get_executable_path.c
+++ b/src/parser/get_executable_path.c
@@ -22,7 +22,7 @@ static int	get_sub_path_len(const char *path)
 	return (i);
 }
 
-static void	get_single_path(const char *all_paths, char *buffer, int size)
+static void	copy_possible_path_to_buffer(const char *all_paths, char *buffer, int size)
 {
 	ft_strlcpy(buffer, all_paths, size + TERMINATOR);
 }
@@ -35,22 +35,19 @@ int	is_executable(char *full_path_executable, struct stat *status)
 char	*get_executable_path(const char *command)
 {
 	const char	*all_paths = getenv(PATH);
-	char		*executable_buffer;
+	char		buffer[CMD_BUFFER_SIZE];
 	int			single_path_len;
 	struct stat	status;
 
-	executable_buffer = calloc(CMD_BUFFER_SIZE, sizeof(char));
-	if (!executable_buffer || !command || !all_paths)
+	if (!command || !all_paths)
 		return (NULL);
 	while (*all_paths)
 	{
 		single_path_len = get_sub_path_len(all_paths);
-		get_single_path(all_paths, executable_buffer, single_path_len);
-		if (single_path_len != (int)ft_strlen(executable_buffer))
-			printf("Not sure if the error check is unnecesary?\n");
-		append_command_to_path(&executable_buffer[single_path_len], command);
-		if (is_executable(executable_buffer, &status) == F_OK)
-			return (executable_buffer);
+		copy_possible_path_to_buffer(all_paths, &buffer[0], single_path_len);
+		append_command_to_path(&buffer[single_path_len], command);
+		if (is_executable(buffer, &status) == F_OK)
+			return (ft_strdup(&buffer[0]));
 		all_paths += single_path_len + 1;
 	}
 	return (NULL);

--- a/src/parser/get_executable_path.c
+++ b/src/parser/get_executable_path.c
@@ -9,7 +9,8 @@
 	getenv(=PATH) returns a string like this: "/bin;usr/bin;usr/sbin;/sbin"
 
 	which is then split on colons
-	I loop through each seperated path to see if it can be accessed with stat() which returns 0 on success otherwise -1
+	I loop through each seperated path to see if it can be accessed with stat()
+	stat() returns 0 on success otherwise -1
 */
 
 char	*get_executable_path(const char *command)
@@ -17,7 +18,7 @@ char	*get_executable_path(const char *command)
 	const char	**all_paths = (const char **)ft_split(getenv("PATH="), ':');
 	char		*executable_path;
 	int			i;
-	struct	stat	buf;
+	struct stat	buf;
 
 	if (!command)
 		return (NULL);

--- a/src/parser/get_executable_path.h
+++ b/src/parser/get_executable_path.h
@@ -4,7 +4,7 @@
 # define PATH "PATH"
 # define COLON ':'
 # define FORWARD_SLASH '/'
-# define CMD_BUFFER_SIZE 256
+# define CMD_BUFFER_SIZE 4096
 # define TERMINATOR 1
 
 # include <defines.h>

--- a/src/parser/get_executable_path.h
+++ b/src/parser/get_executable_path.h
@@ -1,6 +1,6 @@
 #ifndef GET_EXECUTABLE_PATH_H
 # define GET_EXECUTABLE_PATH_H
 
-	char *get_executable_path(const char *command);
+char	*get_executable_path(const char *command);
 
 #endif

--- a/src/parser/get_executable_path.h
+++ b/src/parser/get_executable_path.h
@@ -1,0 +1,6 @@
+#ifndef GET_EXECUTABLE_PATH_H
+# define GET_EXECUTABLE_PATH_H
+
+	char *get_executable_path(const char *command);
+
+#endif

--- a/src/parser/get_executable_path.h
+++ b/src/parser/get_executable_path.h
@@ -1,6 +1,16 @@
 #ifndef GET_EXECUTABLE_PATH_H
 # define GET_EXECUTABLE_PATH_H
 
+# define PATH "PATH"
+# define COLON ':'
+# define FORWARD_SLASH '/'
+# define CMD_BUFFER_SIZE 256
+# define TERMINATOR 1
+
+# include <defines.h>
+# include <sys/stat.h>
+
+int		is_executable(char *full_path_executable, struct stat *status);
 char	*get_executable_path(const char *command);
 
 #endif

--- a/tests/echo_test.c
+++ b/tests/echo_test.c
@@ -27,7 +27,6 @@ CTEST_TEARDOWN(echo_test)
 void	write_to_buf(const char *string_to_write)
 {
 	const int len = strlen(string_to_write);
-
 	strncpy(&echo_buf1[0], string_to_write, len);
 }
 

--- a/tests/get_executable_path_test.c
+++ b/tests/get_executable_path_test.c
@@ -1,0 +1,12 @@
+#include "ctest.h"
+#include "../src/parser/get_executable_path.h"
+
+CTEST(tests_exe_path_return, null_input)
+{
+	ASSERT_NULL(get_executable_path(NULL));
+}
+
+CTEST(tests_exe_path_return, path_for_ls)
+{
+	ASSERT_STR("/bin/ls", get_executable_path("/ls"));
+}

--- a/tests/get_executable_path_test.c
+++ b/tests/get_executable_path_test.c
@@ -9,8 +9,8 @@ CTEST(tests_exe_path_return, null_input)
 CTEST(tests_exe_path_return,incomplete_path)
 {
 	ASSERT_NULL(get_executable_path("ls"));
-	ASSERT_NULL(get_executable_path("      /ls"));
-	ASSERT_NULL(get_executable_path("     /pwd"));
+	// ASSERT_NULL(get_executable_path("      /ls"));
+	// ASSERT_NULL(get_executable_path("     /pwd"));
 }
 
 CTEST(tests_exe_path_return, path_for_valid_commands)

--- a/tests/get_executable_path_test.c
+++ b/tests/get_executable_path_test.c
@@ -6,7 +6,16 @@ CTEST(tests_exe_path_return, null_input)
 	ASSERT_NULL(get_executable_path(NULL));
 }
 
-CTEST(tests_exe_path_return, path_for_ls)
+CTEST(tests_exe_path_return,incomplete_path)
+{
+	ASSERT_NULL(get_executable_path("ls"));
+	ASSERT_NULL(get_executable_path("      /ls"));
+	ASSERT_NULL(get_executable_path("     /pwd"));
+}
+
+CTEST(tests_exe_path_return, path_for_valid_commands)
 {
 	ASSERT_STR("/bin/ls", get_executable_path("/ls"));
+	ASSERT_STR("/bin/cat", get_executable_path("/cat"));
+	ASSERT_STR("/usr/bin/grep", get_executable_path("/grep"));
 }

--- a/tests/get_executable_path_test.c
+++ b/tests/get_executable_path_test.c
@@ -13,9 +13,9 @@ CTEST(tests_exe_path_return, null_input)
 // 	// ASSERT_NULL(get_executable_path("     /pwd"));
 // }
 
-CTEST(tests_exe_path_return, path_for_valid_commands)
-{
-	ASSERT_STR("/bin/ls", get_executable_path("/ls"));
-	ASSERT_STR("/bin/cat", get_executable_path("/cat"));
-	ASSERT_STR("/usr/bin/grep", get_executable_path("/grep"));
-}
+// CTEST(tests_exe_path_return, path_for_valid_commands)
+// {
+// 	ASSERT_STR("/bin/ls", get_executable_path("/ls"));
+// 	ASSERT_STR("/bin/cat", get_executable_path("/cat"));
+// 	ASSERT_STR("/usr/bin/grep", get_executable_path("/grep"));
+// }

--- a/tests/get_executable_path_test.c
+++ b/tests/get_executable_path_test.c
@@ -6,12 +6,12 @@ CTEST(tests_exe_path_return, null_input)
 	ASSERT_NULL(get_executable_path(NULL));
 }
 
-CTEST(tests_exe_path_return,incomplete_path)
-{
-	ASSERT_NULL(get_executable_path("ls"));
-	// ASSERT_NULL(get_executable_path("      /ls"));
-	// ASSERT_NULL(get_executable_path("     /pwd"));
-}
+// CTEST(tests_exe_path_return,incomplete_path)
+// {
+// 	ASSERT_NULL(get_executable_path("ls"));
+// 	// ASSERT_NULL(get_executable_path("      /ls"));
+// 	// ASSERT_NULL(get_executable_path("     /pwd"));
+// }
 
 CTEST(tests_exe_path_return, path_for_valid_commands)
 {

--- a/tests/get_executable_path_test.c
+++ b/tests/get_executable_path_test.c
@@ -1,21 +1,87 @@
 #include "ctest.h"
 #include "../src/parser/get_executable_path.h"
+#include <unistd.h>
+
+CTEST(test_executability, invalid_executable_path)
+{
+	struct stat status;
+	struct stat control;
+	char	*ls_cmd = "bin/l";
+	char	*cat_cmd = "/sbin/cat";
+	char	*grep_cmd = "/usr/bin/grep/";
+
+	ASSERT_EQUAL(stat(ls_cmd,  &control), is_executable(ls_cmd, &status));
+	ASSERT_EQUAL(stat(cat_cmd, &control), is_executable(cat_cmd, &status));
+	ASSERT_EQUAL(stat(grep_cmd, &control), is_executable(grep_cmd, &status));
+}
+
+CTEST(test_executability, executable_path)
+{
+	struct stat status;
+	struct stat control;
+	char	*ls_cmd = "/bin/ls";
+	char	*cat_cmd = "/bin/cat";
+	char	*grep_cmd = "/usr/bin/grep";
+
+	ASSERT_EQUAL(stat(ls_cmd, &control), is_executable(ls_cmd, &status));
+	ASSERT_EQUAL(stat(cat_cmd, &control), is_executable(cat_cmd, &status));
+	ASSERT_EQUAL(stat(grep_cmd, &control), is_executable(grep_cmd, &status));
+}
+
+CTEST(test_executability, invalid_ralative_paths)
+{
+	struct stat status;
+	char	*ls_cmd = "ls";
+	char	*cat_cmd = "cat";
+	char	*grep_cmd = "grep";
+
+	ASSERT_EQUAL(access(ls_cmd, F_OK), is_executable(ls_cmd, &status)); 
+	ASSERT_EQUAL(access(cat_cmd, F_OK), is_executable(cat_cmd, &status)); 
+	ASSERT_EQUAL(access(grep_cmd, F_OK), is_executable(grep_cmd, &status));
+}
+
+CTEST(test_executability, ralative_paths)
+{
+	struct stat status;
+	char	*ls_cmd = "/../../../bin/ls";
+	char	*cat_cmd = "/../../../bin/cat";
+	char	*grep_cmd = "/../../usr/bin/grep";
+
+	ASSERT_EQUAL(access(ls_cmd, F_OK), is_executable(ls_cmd, &status)); 
+	ASSERT_EQUAL(access(cat_cmd, F_OK), is_executable(cat_cmd, &status)); 
+	ASSERT_EQUAL(access(grep_cmd, F_OK), is_executable(grep_cmd, &status)); 
+}
 
 CTEST(tests_exe_path_return, null_input)
 {
 	ASSERT_NULL(get_executable_path(NULL));
 }
 
-// CTEST(tests_exe_path_return,incomplete_path)
-// {
-// 	ASSERT_NULL(get_executable_path("ls"));
-// 	// ASSERT_NULL(get_executable_path("      /ls"));
-// 	// ASSERT_NULL(get_executable_path("     /pwd"));
-// }
 
-// CTEST(tests_exe_path_return, path_for_valid_commands)
-// {
-// 	ASSERT_STR("/bin/ls", get_executable_path("/ls"));
-// 	ASSERT_STR("/bin/cat", get_executable_path("/cat"));
-// 	ASSERT_STR("/usr/bin/grep", get_executable_path("/grep"));
-// }
+CTEST(tests_exe_path_return,incomplete_command)
+{
+	ASSERT_NULL(get_executable_path("l"));
+	ASSERT_NULL(get_executable_path("      /ls"));
+	ASSERT_NULL(get_executable_path("     /pwd"));
+}
+
+CTEST(tests_exe_path_return, invalid_command)
+{
+	ASSERT_NULL(get_executable_path("ltp"));
+	ASSERT_NULL(get_executable_path("cwd"));
+	ASSERT_NULL(get_executable_path("lsv"));
+	ASSERT_NULL(get_executable_path("###"));
+	ASSERT_NULL(get_executable_path("cmd"));
+	ASSERT_NULL(get_executable_path("ls/"));
+	ASSERT_NULL(get_executable_path("      "));
+}
+
+
+CTEST(tests_exe_path_return, path_for_valid_commands)
+{
+	ASSERT_EQUAL(F_OK, access(get_executable_path("ls"), F_OK));
+	ASSERT_EQUAL(F_OK, access(get_executable_path("cat"), F_OK));
+	ASSERT_EQUAL(F_OK, access(get_executable_path("grep"), F_OK));
+	ASSERT_EQUAL(F_OK, access(get_executable_path("clear"), F_OK));
+	ASSERT_EQUAL(F_OK, access(get_executable_path("env"), F_OK));
+}


### PR DESCRIPTION
So I got over excited rebuilding the functionality to exclude as many mallocs as possible. First time doing it this way so please send some tips wherever possible!

The two functions for use is get_executable_path() and is_executable():

get_executable_path:
- Just pushed and realised calloc needs to be changed to ft_calloc :(
- There is an error check on line 49, not sure if it's necessary?

is_executable:
- Basically a stat() call in a return, name is just nicer hehe :) 
- Can't decide if i want it t_bool or not...
- Testing for is_executable is kinda difficult as I can only run it against things that have already been used
- Making it t_bool i can test against expected output, but it will differ from system to system
