### PR TITLE
Export handle more than one variable

### DIFF
--- a/src/env/env_utils.c
+++ b/src/env/env_utils.c
@@ -5,7 +5,7 @@
 #include <ctype.h>
 #include <stdio.h>
 
-static t_bool	is_invalid_key_char(char c)
+t_bool	is_invalid_key_char(char c)
 {
 	return (c == '\0'
 		|| isspace(c)

--- a/src/env/env_utils.c
+++ b/src/env/env_utils.c
@@ -7,7 +7,7 @@
 
 t_bool	is_invalid_key_char(char c)
 {
-	return (c == '\0'
+	return (c == NULL_TERMINATOR
 		|| isspace(c)
 		|| is_quote(c)
 		|| c == VARIABLE_TOKEN

--- a/src/env/env_utils.c
+++ b/src/env/env_utils.c
@@ -5,7 +5,7 @@
 #include <ctype.h>
 #include <stdio.h>
 
-static t_bool	is_valid_key_char(char c)
+t_bool	is_valid_key_char(char c)
 {
 	return (c != NULL_TERMINATOR
 		&& !isspace(c)

--- a/src/env/env_utils.h
+++ b/src/env/env_utils.h
@@ -2,6 +2,7 @@
 # define ENV_UTILS_H
 # include <defines.h>
 
+t_bool	is_invalid_key_char(char c);
 int		get_key_len(const char *key);
 t_bool	is_env_variable(const char *str);
 

--- a/src/env/env_utils.h
+++ b/src/env/env_utils.h
@@ -2,7 +2,7 @@
 # define ENV_UTILS_H
 # include <defines.h>
 
-t_bool	is_invalid_key_char(char c);
+t_bool	is_valid_key_char(char c);
 int		get_key_len(const char *key);
 t_bool	is_env_variable(const char *str);
 

--- a/src/env/environment.c
+++ b/src/env/environment.c
@@ -1,6 +1,7 @@
 #include <env/environment.h>
 #include <env/env_utils.h>
 #include <commands/buffer.h>
+#include <parser/parser.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <libft.h>
@@ -11,14 +12,21 @@ t_bool	export(t_env *env, const char *key_value_str)
 	t_buffer	key_buffer;
 	t_buffer	value_buffer;
 
-	init_buffer(&key_buffer);
-	init_buffer(&value_buffer);
-	if (!copy_key_to_buffer(key_value_str, &key_buffer) || \
-		!copy_value_to_buffer(key_value_str, &value_buffer))
-		return (FALSE);
-	if (!set_key(env, &key_buffer.buf[0]))
-		return (FALSE);
-	return (set_value(env, &key_buffer.buf[0], &value_buffer.buf[0]));
+	while (*key_value_str)
+	{
+		init_buffer(&key_buffer);
+		init_buffer(&value_buffer);
+		if (!copy_key_to_buffer(key_value_str, &key_buffer) || \
+			!copy_value_to_buffer(key_value_str, &value_buffer))
+			return (FALSE);
+		if (!set_key(env, &key_buffer.buf[0])
+			|| !set_value(env, &key_buffer.buf[0], &value_buffer.buf[0]))
+			return (FALSE);
+		while (*key_value_str && !isspace(*key_value_str))
+			++key_value_str;
+		skip_spaces(&key_value_str);
+	}
+	return (TRUE);
 }
 
 void	unset(t_env *env, const char *key)

--- a/src/env/environment.c
+++ b/src/env/environment.c
@@ -22,8 +22,7 @@ t_bool	export(t_env *env, const char *key_value_str)
 		if (!set_key(env, &key_buffer.buf[0])
 			|| !set_value(env, &key_buffer.buf[0], &value_buffer.buf[0]))
 			return (FALSE);
-		while (*key_value_str && !isspace(*key_value_str))
-			++key_value_str;
+		key_value_str += key_buffer.index + value_buffer.index + 1;
 		skip_spaces(&key_value_str);
 	}
 	return (TRUE);

--- a/src/env/export_handle_key.c
+++ b/src/env/export_handle_key.c
@@ -14,7 +14,7 @@ static t_bool	is_valid_key(char *key, int key_len)
 	i = 0;
 	while (i < key_len)
 	{
-		if (isspace(key[i]))
+		if (is_invalid_key_char(key[i]))
 			return (FALSE);
 		++i;
 	}
@@ -24,7 +24,6 @@ static t_bool	is_valid_key(char *key, int key_len)
 t_bool	copy_key_to_buffer(const char *key_value_str, t_buffer *buffer)
 {
 	const char	*delimiter_position = get_equal_sign_position(key_value_str);
-	const int	key_len = delimiter_position - &key_value_str[0];
 	t_arg		str;
 
 	if (!delimiter_position)
@@ -37,7 +36,7 @@ t_bool	copy_key_to_buffer(const char *key_value_str, t_buffer *buffer)
 		else
 			append_char_to_buffer(&str, buffer);
 	}
-	return (is_valid_key(&buffer->buf[0], key_len));
+	return (is_valid_key(&buffer->buf[0], buffer->index));
 }
 
 t_bool	set_key(t_env *env, char *key)

--- a/src/env/export_handle_key.c
+++ b/src/env/export_handle_key.c
@@ -14,7 +14,7 @@ static t_bool	is_valid_key(char *key, int key_len)
 	i = 0;
 	while (i < key_len)
 	{
-		if (is_invalid_key_char(key[i]))
+		if (!is_valid_key_char(key[i]))
 			return (FALSE);
 		++i;
 	}

--- a/src/env/export_handle_value.c
+++ b/src/env/export_handle_value.c
@@ -40,7 +40,11 @@ t_bool	copy_value_to_buffer(const char *key_value_str, t_buffer *buffer)
 		return (FALSE);
 	cur = delimiter_position[0];
 	if (is_quote(cur))
-		return (handle_quoted_value(delimiter_position, buffer));
+	{
+		handle_quoted_value(delimiter_position, buffer);
+		buffer->index += 2;
+		return (TRUE);
+	}
 	return (handle_unquoted_value(delimiter_position, buffer));
 }
 

--- a/src/parser/command_table.c
+++ b/src/parser/command_table.c
@@ -14,7 +14,7 @@ static t_bool	is_valid_last_char(const char *input, int command_len)
 	if (input_len >= command_len)
 	{
 		last_char = input[command_len];
-		return (isspace(last_char) || last_char == '\0');
+		return (isspace(last_char) || last_char == NULL_TERMINATOR);
 	}
 	return (FALSE);
 }

--- a/tests/acceptance/env_feature_bash.sh
+++ b/tests/acceptance/env_feature_bash.sh
@@ -53,6 +53,7 @@ ACTUAL=$(cat $MINISHELL_OUTPUT)
 export TEST_1=1 TEST_2=2 TEST_3=3
 EXPECTED=$(env | grep TEST)
 assertEqual "EXPORT more than one variable"
+unset TEST_1 TEST_2 TEST_3
 
 INPUT='export TEST_4="First env var" TEST_5=5 TEST_6=6'
 runMinishell "$INPUT\nenv | grep TEST_6"
@@ -60,7 +61,8 @@ removePrompt $MINISHELL_OUTPUT
 ACTUAL=$(cat $MINISHELL_OUTPUT)
 export TEST_4="First env var" TEST_5=5 TEST_6=6
 EXPECTED=$(env | grep TEST_6)
-assertEqual "EXPORT more than one variable"
+assertEqual "EXPORT more than one variable with quotes"
+unset TEST_4 TEST_5 TEST_6
 
 INPUT="unset SECOND_VAR"
 runMinishell "$INPUT\nenv | grep SECOND_VAR"

--- a/tests/acceptance/env_feature_bash.sh
+++ b/tests/acceptance/env_feature_bash.sh
@@ -44,6 +44,7 @@ ACTUAL=$(cat $MINISHELL_OUTPUT)
 export SECOND_VAR$USER=testing$USER$USER$
 EXPECTED=$(env | grep SECOND_VAR$USER)
 assertEqual "EXPORT env var with variable in the key"
+unset SECOND_VAR$USER
 
 INPUT='export TEST_1=1 TEST_2=2 TEST_3=3'
 runMinishell "$INPUT\nenv | grep TEST"
@@ -51,6 +52,14 @@ removePrompt $MINISHELL_OUTPUT
 ACTUAL=$(cat $MINISHELL_OUTPUT)
 export TEST_1=1 TEST_2=2 TEST_3=3
 EXPECTED=$(env | grep TEST)
+assertEqual "EXPORT more than one variable"
+
+INPUT='export TEST_4="First env var" TEST_5=5 TEST_6=6'
+runMinishell "$INPUT\nenv | grep TEST_6"
+removePrompt $MINISHELL_OUTPUT
+ACTUAL=$(cat $MINISHELL_OUTPUT)
+export TEST_4="First env var" TEST_5=5 TEST_6=6
+EXPECTED=$(env | grep TEST_6)
 assertEqual "EXPORT more than one variable"
 
 INPUT="unset SECOND_VAR"

--- a/tests/acceptance/env_feature_bash.sh
+++ b/tests/acceptance/env_feature_bash.sh
@@ -45,13 +45,13 @@ export SECOND_VAR$USER=testing$USER$USER$
 EXPECTED=$(env | grep SECOND_VAR$USER)
 assertEqual "EXPORT env var with variable in the key"
 
-INPUT='export SECOND_VAR$USER$=testing$USER$USER$'
-runMinishell "$INPUT\nenv | grep SECOND_VAR$USER"
+INPUT='export TEST_1=1 TEST_2=2 TEST_3=3'
+runMinishell "$INPUT\nenv | grep TEST"
 removePrompt $MINISHELL_OUTPUT
 ACTUAL=$(cat $MINISHELL_OUTPUT)
-# export SECOND_VAR$USER$=testing$USER$USER$
-# EXPECTED=$(env | grep SECOND_VAR$USER)
-# assertEqual "EXPORT env var with variable in the key"
+export TEST_1=1 TEST_2=2 TEST_3=3
+EXPECTED=$(env | grep TEST)
+assertEqual "EXPORT more than one variable"
 
 INPUT="unset SECOND_VAR"
 runMinishell "$INPUT\nenv | grep SECOND_VAR"

--- a/tests/env_api_test.c
+++ b/tests/env_api_test.c
@@ -214,6 +214,19 @@ CTEST2(environment, export_two_variables_together)
     ASSERT_STR(find_variable(data->env, "TEST_3")->value, "ENV_3");
 }
 
+CTEST2(environment, export_all_in_the_same_line)
+{
+    char *pairs[1] = {"TEST_1=ENV_1 TEST_2=\"ENV_2        test\"  TEST_3=ENV_3                   TEST_4=ENV_4    "};
+    
+    ASSERT_TRUE(export(data->env, pairs[0]));
+
+    ASSERT_STR(find_variable(data->env, "TEST_1")->value, "ENV_1");
+    ASSERT_STR(find_variable(data->env, "TEST_2")->value, "ENV_2        test");
+    ASSERT_STR(find_variable(data->env, "TEST_3")->value, "ENV_3");
+    ASSERT_STR(find_variable(data->env, "TEST_4")->value, "ENV_4");
+
+}
+
 CTEST2(environment, export_with_double_quotes)
 {
     char *pairs[4] = {

--- a/tests/env_api_test.c
+++ b/tests/env_api_test.c
@@ -200,19 +200,18 @@ CTEST2(environment, export_new_value_for_existent_key)
     ASSERT_STR(find_variable(data->env, "TEST_2")->value, "ENV_2_NEW_VALUE");
 }
 
-CTEST2(environment, export_with_space_in_value)
+CTEST2(environment, export_two_variables_together)
 {
-    char *pairs[4] = {
+    char *pairs[3] = {
         "TEST_1=ENV_1",
-        "TEST_2=ENV_2 TEST",
-        "TEST_3=ENV_3",
+        "TEST_2=ENV_2       TEST_3=ENV_3",
         "TEST_4=ENV_4",
     };
     
-    for (int i = 0; i < 4; ++i)
+    for (int i = 0; i < 3; ++i)
         ASSERT_TRUE(export(data->env, pairs[i]));
 
-    ASSERT_STR(find_variable(data->env, "TEST_2")->value, "ENV_2");
+    ASSERT_STR(find_variable(data->env, "TEST_3")->value, "ENV_3");
 }
 
 CTEST2(environment, export_with_double_quotes)
@@ -225,7 +224,7 @@ CTEST2(environment, export_with_double_quotes)
     };
     
     for (int i = 0; i < 4; ++i)
-        ASSERT_TRUE(export(data->env, pairs[i]));
+        export(data->env, pairs[i]);
     ASSERT_STR(find_variable(data->env, "TEST_2")->value, "ENV_2    TEST");
 }
 

--- a/tests/env_api_test.c
+++ b/tests/env_api_test.c
@@ -238,7 +238,7 @@ CTEST2(environment, export_with_double_quotes_and_var)
     };
     
     for (int i = 0; i < 4; ++i)
-        ASSERT_TRUE(export(data->env, pairs[i]));
+        export(data->env, pairs[i]);
     ASSERT_STR(find_variable(data->env, "TEST_2")->value, "ENV_2    ENV_1");
 }
 
@@ -252,7 +252,7 @@ CTEST2(environment, export_with_var_in_the_key)
     };
     
     for (int i = 0; i < 4; ++i)
-        ASSERT_TRUE(export(data->env, pairs[i]));
+        export(data->env, pairs[i]);
     ASSERT_STR(find_variable(data->env, "TEST_2ENV_1")->key, "TEST_2ENV_1");
 }
 


### PR DESCRIPTION
# env_utils.c
- is_valid_key_char(char c);
 Isn't static anymore because it's used somewhere else.
# environment.c
- export() gets the first variable and update the key_value_pair with the value of key_buffer.index and value_buffer.index +1 because of '='; 
# export_handle_key.c
- Using is_valid_key_char instead of is space
# export_handle_value.c
- If handling quoted value, I'm doing buffer->index += 2, so export() will also advance the quotes and keep searching for variables.
# command_table.c
- Just added the NULL_TERMINATOR macro.