### PR TITLE
Fix export bug on key and value len

### DIFF
--- a/src/env/env_utils.c
+++ b/src/env/env_utils.c
@@ -1,15 +1,12 @@
 #include <ctype.h>
+#include <libft.h>
 #include <commands/quotes.h>
 #include <commands/commands.h>
 #include <env/env_utils.h>
 
 t_bool	is_valid_key_char(char c)
 {
-	return (c != NULL_TERMINATOR
-		&& !isspace(c)
-		&& !is_quote(c)
-		&& c != VARIABLE_TOKEN
-		&& c != EQUAL_SIGN);
+	return (ft_isalnum(c) || c == '_');
 }
 
 int	get_key_len(const char *key)

--- a/src/env/export_handle_key.c
+++ b/src/env/export_handle_key.c
@@ -1,5 +1,6 @@
 #include <ctype.h>
 #include <libft.h>
+#include <stdio.h>
 #include <commands/echo_utils.h>
 #include <commands/quotes.h>
 #include <env/environment.h>
@@ -35,7 +36,10 @@ t_bool	copy_key_to_buffer(const char *key_value_str, t_buffer *buffer)
 		else
 			append_char_to_buffer(&str, buffer);
 	}
-	return (is_valid_key(&buffer->buf[0], buffer->index));
+	if (!is_valid_key(&buffer->buf[0], buffer->index))
+		return (FALSE);
+	buffer->index = delimiter_position - key_value_str;
+	return (TRUE);
 }
 
 t_bool	set_key(t_env *env, char *key)

--- a/src/env/export_handle_value.c
+++ b/src/env/export_handle_value.c
@@ -29,9 +29,11 @@ void	handle_unquoted_value(const char *value, t_buffer *buffer)
 	}
 }
 
-static int get_value_len(const char *value_string)
+static int	get_value_len(const char *value_string)
 {
-	int i = 0;
+	int	i;
+
+	i = 0;
 	while (value_string[i])
 	{
 		if (isspace(value_string[i]) \
@@ -44,7 +46,8 @@ static int get_value_len(const char *value_string)
 
 t_bool	copy_value_to_buffer(const char *key_value_str, t_buffer *buffer)
 {
-	const char	*delimiter_position = get_equal_sign_position(key_value_str) + 1;
+	const char	*delimiter_position = \
+		get_equal_sign_position(key_value_str) + 1;
 	char		cur;
 
 	if (!delimiter_position)

--- a/src/env/export_handle_value.c
+++ b/src/env/export_handle_value.c
@@ -5,6 +5,7 @@
 #include <commands/quotes.h>
 #include <env/environment.h>
 #include <env/env_utils.h>
+#include <parser/command_table.h>
 
 t_bool	handle_quoted_value(const char *value, t_buffer *buffer)
 {
@@ -33,22 +34,17 @@ t_bool	handle_unquoted_value(const char *value, t_buffer *buffer)
 t_bool	copy_value_to_buffer(const char *key_value_str, t_buffer *buffer)
 {
 	const char	*delimiter_position = get_equal_sign_position(key_value_str) + 1;
-	const t_quotes_position	quotes_pos = get_quotes_positions(delimiter_position);
+	// const t_quotes_position	quotes_pos = get_quotes_positions(delimiter_position);
 	char		cur;
 
 	if (!delimiter_position)
 		return (FALSE);
 	cur = delimiter_position[0];
 	if (is_quote(cur))
-	{
 		handle_quoted_value(delimiter_position, buffer);
-		buffer->index = (quotes_pos.end + 1) - delimiter_position;
-		return (TRUE);
-	}
-	handle_unquoted_value(delimiter_position, buffer);
-	buffer->index = 0;
-	while (delimiter_position[buffer->index] && !isspace(delimiter_position[buffer->index]))
-		++buffer->index;
+	else
+		handle_unquoted_value(delimiter_position, buffer);
+	buffer->index = get_set_index((char *)delimiter_position, " \0");
 	return (TRUE);
 }
 

--- a/src/env/export_handle_value.c
+++ b/src/env/export_handle_value.c
@@ -1,4 +1,5 @@
 #include <ctype.h>
+#include <stdio.h>
 #include <libft.h>
 #include <commands/echo_utils.h>
 #include <commands/quotes.h>
@@ -31,8 +32,8 @@ t_bool	handle_unquoted_value(const char *value, t_buffer *buffer)
 
 t_bool	copy_value_to_buffer(const char *key_value_str, t_buffer *buffer)
 {
-	const char	*delimiter_position =
-		get_equal_sign_position(key_value_str) + 1;
+	const char	*delimiter_position = get_equal_sign_position(key_value_str) + 1;
+	const t_quotes_position	quotes_pos = get_quotes_positions(delimiter_position);
 	char		cur;
 
 	if (!delimiter_position)
@@ -41,10 +42,14 @@ t_bool	copy_value_to_buffer(const char *key_value_str, t_buffer *buffer)
 	if (is_quote(cur))
 	{
 		handle_quoted_value(delimiter_position, buffer);
-		buffer->index += 2;
+		buffer->index = (quotes_pos.end + 1) - delimiter_position;
 		return (TRUE);
 	}
-	return (handle_unquoted_value(delimiter_position, buffer));
+	handle_unquoted_value(delimiter_position, buffer);
+	buffer->index = 0;
+	while (delimiter_position[buffer->index] && !isspace(delimiter_position[buffer->index]))
+		++buffer->index;
+	return (TRUE);
 }
 
 t_bool	set_value(t_env *env, char *key, char *value)

--- a/src/env/export_handle_value.c
+++ b/src/env/export_handle_value.c
@@ -7,16 +7,15 @@
 #include <env/env_utils.h>
 #include <parser/command_table.h>
 
-t_bool	handle_quoted_value(const char *value, t_buffer *buffer)
+void	handle_quoted_value(const char *value, t_buffer *buffer)
 {
 	t_arg		arg;
 
 	arg.start = value;
 	parse_str_with_quotes(arg, buffer);
-	return (TRUE);
 }
 
-t_bool	handle_unquoted_value(const char *value, t_buffer *buffer)
+void	handle_unquoted_value(const char *value, t_buffer *buffer)
 {
 	t_arg	str;
 
@@ -28,13 +27,24 @@ t_bool	handle_unquoted_value(const char *value, t_buffer *buffer)
 		else
 			append_char_to_buffer(&str, buffer);
 	}
-	return (TRUE);
+}
+
+static int get_value_len(const char *value_string)
+{
+	int i = 0;
+	while (value_string[i])
+	{
+		if (isspace(value_string[i]) \
+		&& !is_between_quotes(value_string, i))
+			return (i);
+		++i;
+	}
+	return (i);
 }
 
 t_bool	copy_value_to_buffer(const char *key_value_str, t_buffer *buffer)
 {
 	const char	*delimiter_position = get_equal_sign_position(key_value_str) + 1;
-	// const t_quotes_position	quotes_pos = get_quotes_positions(delimiter_position);
 	char		cur;
 
 	if (!delimiter_position)
@@ -44,7 +54,7 @@ t_bool	copy_value_to_buffer(const char *key_value_str, t_buffer *buffer)
 		handle_quoted_value(delimiter_position, buffer);
 	else
 		handle_unquoted_value(delimiter_position, buffer);
-	buffer->index = get_set_index((char *)delimiter_position, " \0");
+	buffer->index = get_value_len(delimiter_position);
 	return (TRUE);
 }
 

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -9,6 +9,6 @@ void	advance_pointer(const char **input, const char *parsed_str)
 
 void	skip_spaces(const char **input)
 {
-	while (isspace(*(*input)))
+	while (*input && isspace(*(*input)))
 		++(*input);
 }

--- a/tests/acceptance/env_feature_bash.sh
+++ b/tests/acceptance/env_feature_bash.sh
@@ -4,8 +4,6 @@ source ./tests/acceptance/common.sh
 
 printTestName "ENV"
 
-
-
 export FIRST_VAR=Hello
 INPUT="env | grep FIRST_VAR"
 runMinishell "$INPUT"
@@ -54,6 +52,16 @@ export TEST_1=1 TEST_2=2 TEST_3=3
 EXPECTED=$(env | grep TEST_3)
 assertEqual "EXPORT more than one variable"
 unset TEST_1 TEST_2 TEST_3
+
+
+INPUT='export TEST_1_$USER=1 TEST_2=2 TEST_3=3'
+runMinishell "$INPUT\nenv | grep TEST_3"
+removePrompt $MINISHELL_OUTPUT
+ACTUAL=$(cat $MINISHELL_OUTPUT)
+export TEST_1_$USER=1 TEST_2=2 TEST_3=3
+EXPECTED=$(env | grep TEST_3)
+assertEqual "EXPORT more than one variable with env variable in name"
+unset TEST_1_$USER TEST_2 TEST_3
 
 INPUT='export TEST_4="First env var" TEST_5=5 TEST_6=6'
 runMinishell "$INPUT\nenv | grep TEST_6"

--- a/tests/acceptance/env_feature_bash.sh
+++ b/tests/acceptance/env_feature_bash.sh
@@ -72,6 +72,15 @@ EXPECTED=$(env | grep TEST_6)
 assertEqual "EXPORT more than one variable with quotes"
 unset TEST_4 TEST_5 TEST_6
 
+runMinishell "export key='test with single quotes' TEST_5=5 TEST_6=6\nenv | grep TEST_5"
+removePrompt $MINISHELL_OUTPUT
+ACTUAL=$(cat $MINISHELL_OUTPUT)
+export key='test with single quotes' TEST_5=5 TEST_6=6
+EXPECTED=$(env | grep TEST_5)
+assertEqual "EXPORT more than one variable with single quotes"
+unset TEST_4 TEST_5 TEST_6
+
+
 INPUT="unset SECOND_VAR"
 runMinishell "$INPUT\nenv | grep SECOND_VAR"
 removePrompt $MINISHELL_OUTPUT

--- a/tests/acceptance/env_feature_bash.sh
+++ b/tests/acceptance/env_feature_bash.sh
@@ -63,11 +63,11 @@ EXPECTED=$(env | grep TEST_3)
 assertEqual "EXPORT more than one variable with env variable in name"
 unset TEST_1_$USER TEST_2 TEST_3
 
-INPUT='export TEST_4="First env var" TEST_5=5 TEST_6=6'
+INPUT='export TEST_4="$PATH" TEST_5=5 TEST_6=6'
 runMinishell "$INPUT\nenv | grep TEST_6"
 removePrompt $MINISHELL_OUTPUT
 ACTUAL=$(cat $MINISHELL_OUTPUT)
-export TEST_4="First env var" TEST_5=5 TEST_6=6
+export TEST_4="$PATH" TEST_5=5 TEST_6=6
 EXPECTED=$(env | grep TEST_6)
 assertEqual "EXPORT more than one variable with quotes"
 unset TEST_4 TEST_5 TEST_6

--- a/tests/env_api_test.c
+++ b/tests/env_api_test.c
@@ -295,6 +295,6 @@ CTEST2(environment, string_with_single_quote_as_value)
 {
     char *pair = "key='test with single quotes'";
     
-    ASSERT_TRUE(export(data->env, pair));
+    export(data->env, pair);
     ASSERT_STR(find_variable(data->env, "key")->value, "test with single quotes");
 }

--- a/tests/env_api_test.c
+++ b/tests/env_api_test.c
@@ -295,6 +295,6 @@ CTEST2(environment, string_with_single_quote_as_value)
 {
     char *pair = "key='test with single quotes'";
     
-    export(data->env, pair);
+    ASSERT_TRUE(export(data->env, pair));
     ASSERT_STR(find_variable(data->env, "key")->value, "test with single quotes");
 }


### PR DESCRIPTION
### src/env/env_utils.c
- Yeah, no need to say that comparing two things is better then 5..
### src/env/export_handle_key.c
- Returning FALSE when key is invalid and redefining buffer->index value to be the length from the beginning string until the =.
### src/env/export_handle_value.c
- Wrote simple function to get first occurrence of space that isn't between quotes.
### src/parser/parser_utils.c
- Added extra check before isspace() because it can segf.