### PR TITLE
Cd command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
         "get_executable_path.h": "c",
         "ios": "c",
         "readline.h": "c",
-        "history.h": "c"
+        "history.h": "c",
+        "commands.h": "c"
     },
     "python.linting.flake8Args": [
         "--max-line-length=120",

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ MINISHELL_SRC= 							\
 	src/commands/buffer.c				\
 	src/commands/pwd_command.c			\
 	src/commands/environment_commands.c	\
+	src/commands/cd_command.c			\
 	src/env/environment.c				\
 	src/env/environment_utils.c			\
 	src/env/export_handle_key.c			\

--- a/src/commands/cd_command.c
+++ b/src/commands/cd_command.c
@@ -8,7 +8,7 @@
 
 void	update_env(char *cwd_value)
 {
-	char *current_directory;
+	char	*current_directory;
 
 	current_directory = getcwd(NULL, 0);
 	if (!current_directory)
@@ -18,16 +18,15 @@ void	update_env(char *cwd_value)
 	find_variable(get_environment(), "PWD")->value = current_directory;
 }
 
-t_exit_code cd_command(t_command command, t_output_stdout output)
+t_exit_code	cd_command(t_command command, t_output_stdout output)
 {
-	t_env		*pwd = find_variable(get_environment(), "PWD");
+	const t_env	*pwd = find_variable(get_environment(), "PWD");
 	char		command_buffer[BUFFER_SIZE];
 
+	(void)output;
 	if (!pwd)
 		return (ERROR);
 	ft_strlcpy(command_buffer, command.arg.start, command.arg.len + 1);
-	(void)output;
-	
 	if (chdir(command_buffer) == SYS_ERROR)
 		return (ERROR);
 	update_env(pwd->value);

--- a/src/commands/cd_command.c
+++ b/src/commands/cd_command.c
@@ -1,0 +1,35 @@
+#include <defines.h>
+#include <libft.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <commands/commands.h>
+#include <env/environment.h>
+#include <executor/run_commands.h>
+
+void	update_env(char *cwd_value)
+{
+	char *current_directory;
+
+	current_directory = getcwd(NULL, 0);
+	if (!current_directory)
+		return ;
+	export(get_environment(), "OLDPWD=");
+	find_variable(get_environment(), "OLDPWD")->value = cwd_value;
+	find_variable(get_environment(), "PWD")->value = current_directory;
+}
+
+t_exit_code cd_command(t_command command, t_output_stdout output)
+{
+	t_env		*pwd = find_variable(get_environment(), "PWD");
+	char		command_buffer[BUFFER_SIZE];
+
+	if (!pwd)
+		return (ERROR);
+	ft_strlcpy(command_buffer, command.arg.start, command.arg.len + 1);
+	(void)output;
+	
+	if (chdir(command_buffer) == SYS_ERROR)
+		return (ERROR);
+	update_env(pwd->value);
+	return (SUCCESS);
+}

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -48,5 +48,6 @@ t_exit_code	pwd_command(t_command command, t_output_stdout output);
 t_exit_code	export_command(t_command command, t_output_stdout output);
 t_exit_code	unset_command(t_command command, t_output_stdout output);
 t_exit_code	env_command(t_command command, t_output_stdout output);
+t_exit_code	cd_command(t_command command, t_output_stdout output);
 
 #endif

--- a/src/defines.h
+++ b/src/defines.h
@@ -21,6 +21,7 @@ typedef enum e_command_code
 	EXPORT,
 	UNSET,
 	ENV,
+	CD,
 	INVALID,
 	SYSTEM,
 	LAST,

--- a/src/executor/run_commands.c
+++ b/src/executor/run_commands.c
@@ -46,7 +46,7 @@ static t_bool	is_env_command(t_command_code code)
 
 t_bool	is_single_command(int num_of_cmds, t_command_code code)
 {
-	return (num_of_cmds == 1 && (code == EXIT || is_env_command(code)));
+	return (num_of_cmds == 1 && (code == EXIT || is_env_command(code) || code == CD));
 }
 
 /*

--- a/src/executor/run_commands.c
+++ b/src/executor/run_commands.c
@@ -41,12 +41,12 @@ int	run_multi_processes(char *env[],
 
 static t_bool	is_env_command(t_command_code code)
 {
-	return (code == EXPORT || code == UNSET || code == ENV);
+	return (code == EXPORT || code == UNSET || code == ENV || code == CD);
 }
 
 t_bool	is_single_command(int num_of_cmds, t_command_code code)
 {
-	return (num_of_cmds == 1 && (code == EXIT || is_env_command(code) || code == CD));
+	return (num_of_cmds == 1 && (code == EXIT || is_env_command(code)));
 }
 
 /*

--- a/src/parser/command_table.c
+++ b/src/parser/command_table.c
@@ -34,7 +34,7 @@ t_command_code	get_command_code(const char **input, t_command *command)
 {
 	static const char	*commands[LAST] = {"", "echo", "exit", "pwd",
 											"export", "unset", "env",
-											"cd" ,"invalid"
+											"cd", "invalid"
 										};
 	t_command_code		command_code;
 

--- a/src/parser/command_table.c
+++ b/src/parser/command_table.c
@@ -34,7 +34,7 @@ t_command_code	get_command_code(const char **input, t_command *command)
 {
 	static const char	*commands[LAST] = {"", "echo", "exit", "pwd",
 											"export", "unset", "env",
-											"invalid"
+											"cd" ,"invalid"
 										};
 	t_command_code		command_code;
 

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -50,6 +50,7 @@ t_exit_code	dispatch_command(const t_command *command, char *env[])
 															export_command,
 															unset_command,
 															env_command,
+															cd_command,
 															unknown_command,
 															};
 

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -29,6 +29,7 @@ t_command	populate_command(const char **input_ptr)
 	command.files = get_redirection((char **)input_ptr,
 			get_set_index(*input_ptr, "|") - 1);
 	command.code = get_command_code(input_ptr, &command);
+	skip_spaces(input_ptr);
 	command.arg.start = *input_ptr;
 	command.arg.len = get_set_index(command.arg.start, "|");
 	command.arg.end = *input_ptr + command.arg.len;


### PR DESCRIPTION
### Basic implementation of CD

- cd_command(t_command command, t_output_stdout output)
- update_env(char *cwd_value)

Use of env vars as arguments still need to be added.

Special args like '~' and empty cd still need to be implemented