### PR TITLE
Env var as command

### DIFF
--- a/src/output/prompt.c
+++ b/src/output/prompt.c
@@ -1,7 +1,7 @@
 #include <libft.h>
 #include <unistd.h>
 #include <output/prompt.h>
-#define COLOR "\e[1;36m "
+#define COLOR "\e[1;36m"
 #define RESET_COLOR " -► \e[0m "
 
 char	*display_prompt(char *buffer)

--- a/src/parser/command_table.h
+++ b/src/parser/command_table.h
@@ -1,11 +1,13 @@
 #ifndef COMMAND_TABLE_H
 # define COMMAND_TABLE_H
+# include <commands/buffer.h>
 # include <commands/commands.h>
 # include <defines.h>
 
 t_command_code	get_command_code(const char **input, t_command *command);
 t_bool			is_between_quotes(const char *input, int reserved_char_index);
 int				get_set_index(const char *start, const char *set);
+t_command		*expand_arg_content(t_command *command, t_buffer *buffer);
 t_bool			is_system_command(const char *input, t_command *command);
 char			*get_set_position(const char *set, char *str_to_check);
 void			cleanup_command_table(t_command *command_table, \

--- a/src/parser/command_table_utils.c
+++ b/src/parser/command_table_utils.c
@@ -3,6 +3,17 @@
 #include <parser/command_table.h>
 #include <parser/get_executable_path.h>
 
+t_command	*expand_arg_content(t_command *command, t_buffer *buffer)
+{
+	while (command->arg.start < command->arg.end)
+		append_expanded_input_to_buffer((t_arg *)(&command->arg), buffer);
+	command->arg.start = (char *)buffer->buf;
+	command->code = get_command_code(&command->arg.start, command);
+	command->arg.len = ft_strlen(command->arg.start);
+	command->arg.end = command->arg.start + command->arg.len;
+	return (command);
+}
+
 /*
 	get_executable_path only returns a string if passed command or path,
 	is executable.

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -57,6 +57,8 @@ t_exit_code	dispatch_command(t_command *command, char *env[])
 															};
 	t_buffer	buffer;
 	t_arg	str;
+
+	// should expand variables in all commands (cd, grep ..)
 	init_buffer(&buffer);
 	if (command->code == INVALID)
 	{

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -1,5 +1,6 @@
 #include <ctype.h>
 #include <libft.h>
+#include <stdio.h>
 #include <parser/dispatcher.h>
 #include <commands/buffer.h>
 #include <commands/commands.h>
@@ -56,23 +57,10 @@ t_exit_code	dispatch_command(t_command *command, char *env[])
 															unknown_command,
 															};
 	t_buffer	buffer;
-	t_arg	str;
-
-	// should expand variables in all commands (cd, grep ..)
+	
 	init_buffer(&buffer);
-	if (command->code == INVALID)
-	{
-		if (is_env_variable(command->arg.start))
-		{
-			while (command->arg.start < command->arg.end)
-				append_expanded_input_to_buffer((t_arg *)(&command->arg), &buffer);	
-			str.start = (char *)buffer.buf;
-			command->code = get_command_code(&str.start, command);
-			command->arg.start = str.start;
-			command->arg.end = command->arg.start + buffer.index;
-			command->arg.len = command->arg.end - command->arg.start;
-		}
-	}
+	if (command->code == INVALID && is_env_variable(command->arg.start))
+		command = expand_arg_content(command, &buffer);
 	if (command->code == SYSTEM)
 		execute_system_command(command, env);
 	else if (command->code == INVALID)

--- a/src/parser/dispatcher.c
+++ b/src/parser/dispatcher.c
@@ -46,6 +46,7 @@ t_exit_code	empty_command(t_command command, t_output_stdout write_to_stdout)
 
 t_exit_code	dispatch_command(t_command *command, char *env[])
 {
+	t_buffer							buffer;
 	static const t_command_function		functions[LAST] = {
 															empty_command,
 															echo_command,
@@ -56,8 +57,7 @@ t_exit_code	dispatch_command(t_command *command, char *env[])
 															env_command,
 															unknown_command,
 															};
-	t_buffer	buffer;
-	
+
 	init_buffer(&buffer);
 	if (command->code == INVALID && is_env_variable(command->arg.start))
 		command = expand_arg_content(command, &buffer);

--- a/src/parser/dispatcher.h
+++ b/src/parser/dispatcher.h
@@ -6,6 +6,6 @@
 typedef t_exit_code(*t_command_function)(t_command, t_output_stdout);
 
 t_exit_code	unknown_command(t_command command, t_output_stdout output);
-t_exit_code	dispatch_command(const t_command *command, char *env[]);
+t_exit_code	dispatch_command(t_command *command, char *env[]);
 
 #endif

--- a/tests/acceptance/acceptance_test.sh
+++ b/tests/acceptance/acceptance_test.sh
@@ -27,6 +27,9 @@ RESULT+=$?
 ./tests/acceptance/redirection_feature_bash.sh
 RESULT+=$?
 
+./tests/acceptance/variable_feature_bash.sh
+RESULT+=$?
+
 ./tests/acceptance/syntax_checker_test.sh
 RESULT+=$?
 

--- a/tests/acceptance/variable_feature_bash.sh
+++ b/tests/acceptance/variable_feature_bash.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+source ./tests/acceptance/common.sh
+
+printTestName "Commands_in_variables"
+
+INPUT="export TEST=echo\n\$TEST hello you | cat -e"
+runMinishell "$INPUT"
+removePrompt $MINISHELL_OUTPUT
+ACTUAL=$(cat $MINISHELL_OUTPUT)
+export TEST=echo
+EXPECTED=$($TEST hello you | cat -e)
+assertEqual "Variable echo"
+cleanUp
+
+INPUT="export TEST=\"echo  testing\"\n\$TEST hello you | cat -e"
+runMinishell "$INPUT"
+removePrompt $MINISHELL_OUTPUT
+ACTUAL=$(cat $MINISHELL_OUTPUT)
+export TEST="echo  testing"
+EXPECTED=$($TEST hello you | cat -e)
+assertEqual "Variable echo"
+cleanUp
+
+INPUT="export TEST=\"cat -e\"\necho hello you | \$TEST | \$TEST | \$TEST | \$TEST | \$TEST"
+runMinishell "$INPUT"
+removePrompt $MINISHELL_OUTPUT
+ACTUAL=$(cat $MINISHELL_OUTPUT)
+export TEST="cat -e"
+EXPECTED=$(echo hello you | $TEST | $TEST | $TEST | $TEST | $TEST)
+assertEqual "Variable after pipe"
+cleanUp
+
+exit $EXIT_CODE


### PR DESCRIPTION
created the function:
```C
t_command	*expand_arg_content(t_command *command, t_buffer *buffer)
```
and added to command_table_utils because I might use the same function inside the system commands to expand the variable, for example: ```cat $FILENAME ```

