### PR TITLE
Stop execution on file error

### DIFF
--- a/src/commands/cd_command.c
+++ b/src/commands/cd_command.c
@@ -42,7 +42,9 @@ t_exit_code	cd_command(t_command command, t_output_stdout output)
 	t_buffer	buffer;
 
 	(void)output;
-	getcwd(cwd_before_cd, BUFFER_SIZE);
+	if (!getcwd(cwd_before_cd, BUFFER_SIZE))
+		printf("FAILLLED: %s\n", cwd_before_cd);
+	
 	init_buffer(&buffer);
 	if (command.arg.len == 0 || *command.arg.start == '~')
 		copy_home_var_to_buffer(buffer.buf);

--- a/src/commands/cd_command.c
+++ b/src/commands/cd_command.c
@@ -42,9 +42,7 @@ t_exit_code	cd_command(t_command command, t_output_stdout output)
 	t_buffer	buffer;
 
 	(void)output;
-	if (!getcwd(cwd_before_cd, BUFFER_SIZE))
-		printf("FAILLLED: %s\n", cwd_before_cd);
-	
+	getcwd(cwd_before_cd, BUFFER_SIZE);
 	init_buffer(&buffer);
 	if (command.arg.len == 0 || *command.arg.start == '~')
 		copy_home_var_to_buffer(buffer.buf);

--- a/src/commands/pwd_command.c
+++ b/src/commands/pwd_command.c
@@ -7,10 +7,10 @@ char	*get_pwd(char *buffer)
 	const t_env	*pwd = find_variable(get_environment(), "PWD");
 
 	getcwd(buffer, BUFFER_SIZE);
-	if (!buffer && !pwd)
+	if (!*buffer && !pwd)
 		return (NULL);
-	else if (!buffer && pwd && pwd->value)
-		buffer = pwd->value;
+	else if (!*buffer && pwd && pwd->value)
+		ft_strlcpy(buffer, pwd->value, ft_strlen(pwd->value) + 1);
 	return (buffer);
 }
 

--- a/src/commands/pwd_command.c
+++ b/src/commands/pwd_command.c
@@ -1,13 +1,29 @@
 #include <libft.h>
+#include <env/environment.h>
 #include <commands/commands.h>
 
+char	*get_pwd(char *buffer)
+{
+	const t_env *pwd = find_variable(get_environment(), "PWD");
+
+	getcwd(buffer, BUFFER_SIZE);
+	if (!buffer && !pwd)
+		return (NULL);
+	else if (!buffer && pwd && pwd->value)
+		buffer = pwd->value;
+	return (buffer);
+}
+
+// Should write a error on line 12 as nothing in env and getcwd doesnt work
 t_exit_code	pwd_command(t_command command, t_output_stdout output)
 {
-	command.arg.start = getcwd(NULL, 0);
-	if (!command.arg.start)
+	t_buffer buffer;
+
+	(void)command;
+	init_buffer(&buffer);
+	if (!get_pwd(buffer.buf))
 		return (ERROR);
-	output(command.arg.start);
+	output(buffer.buf);
 	output("\n");
-	free((char *)command.arg.start);
 	return (SUCCESS);
 }

--- a/src/commands/pwd_command.c
+++ b/src/commands/pwd_command.c
@@ -4,7 +4,7 @@
 
 char	*get_pwd(char *buffer)
 {
-	const t_env *pwd = find_variable(get_environment(), "PWD");
+	const t_env	*pwd = find_variable(get_environment(), "PWD");
 
 	getcwd(buffer, BUFFER_SIZE);
 	if (!buffer && !pwd)
@@ -17,7 +17,7 @@ char	*get_pwd(char *buffer)
 // Should write a error on line 12 as nothing in env and getcwd doesnt work
 t_exit_code	pwd_command(t_command command, t_output_stdout output)
 {
-	t_buffer buffer;
+	t_buffer	buffer;
 
 	(void)command;
 	init_buffer(&buffer);

--- a/src/commands/pwd_command_utils.h
+++ b/src/commands/pwd_command_utils.h
@@ -1,0 +1,6 @@
+#ifndef PWD_COMMAND_UTILS_H
+# define PWD_COMMAND_UTILS_H
+
+char	*get_pwd(char *buffer);
+
+#endif

--- a/src/output/prompt.c
+++ b/src/output/prompt.c
@@ -5,7 +5,6 @@
 #include <env/environment.h>
 #include <output/prompt.h>
 
-
 #define COLOR "\e[1;36m"
 #define RED "\e[0;31m"
 #define RESET_COLOR " -► \e[0m "

--- a/src/output/prompt.c
+++ b/src/output/prompt.c
@@ -1,27 +1,33 @@
 #include <libft.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <commands/pwd_command_utils.h>
 #include <env/environment.h>
 #include <output/prompt.h>
 
 
 #define COLOR "\e[1;36m"
+#define RED "\e[0;31m"
 #define RESET_COLOR " -► \e[0m "
 
 char	*display_prompt(char *buffer)
 {
-	// const char	*path = getcwd(NULL, 0);
-	const char	*path = find_variable(get_environment(), "PWD")->value;
-	if (!path)
-		printf("GETCWD FAILED!\n");
-	const int	path_len = ft_strlen(path) + 1;
 	const int	color_len = ft_strlen(COLOR) + 1;
 	const int	reset_color_len = ft_strlen(RESET_COLOR);
+	t_buffer	path;
+	int			path_len;
 
+	init_buffer(&path);
 	ft_bzero(buffer, sizeof(buffer));
+	if (!get_pwd(path.buf))
+	{
+		ft_strlcpy(buffer, RED, color_len);
+		ft_strlcpy(&buffer[ft_strlen(buffer)], "WHY THOUGH???", 14);
+		return (buffer);
+	}
+	path_len = ft_strlen(path.buf) + 1;
 	ft_strlcpy(buffer, COLOR, color_len);
-	ft_strlcpy(&buffer[ft_strlen(buffer)], path, path_len);
+	ft_strlcpy(&buffer[ft_strlen(buffer)], path.buf, path_len);
 	ft_strlcpy(&buffer[ft_strlen(buffer)], RESET_COLOR, reset_color_len);
-	// free((char *)path);
 	return (buffer);
 }

--- a/src/output/prompt.c
+++ b/src/output/prompt.c
@@ -1,12 +1,19 @@
 #include <libft.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <env/environment.h>
 #include <output/prompt.h>
+
+
 #define COLOR "\e[1;36m"
 #define RESET_COLOR " -► \e[0m "
 
 char	*display_prompt(char *buffer)
 {
-	const char	*path = getcwd(NULL, 0);
+	// const char	*path = getcwd(NULL, 0);
+	const char	*path = find_variable(get_environment(), "PWD")->value;
+	if (!path)
+		printf("GETCWD FAILED!\n");
 	const int	path_len = ft_strlen(path) + 1;
 	const int	color_len = ft_strlen(COLOR) + 1;
 	const int	reset_color_len = ft_strlen(RESET_COLOR);
@@ -15,6 +22,6 @@ char	*display_prompt(char *buffer)
 	ft_strlcpy(buffer, COLOR, color_len);
 	ft_strlcpy(&buffer[ft_strlen(buffer)], path, path_len);
 	ft_strlcpy(&buffer[ft_strlen(buffer)], RESET_COLOR, reset_color_len);
-	free((char *)path);
+	// free((char *)path);
 	return (buffer);
 }

--- a/src/output/prompt.c
+++ b/src/output/prompt.c
@@ -6,7 +6,7 @@
 #include <output/prompt.h>
 
 #define COLOR "\e[1;36m"
-#define RED "\e[0;31m"
+#define RED "\e[1;31m"
 #define RESET_COLOR " -► \e[0m "
 
 char	*display_prompt(char *buffer)
@@ -22,6 +22,7 @@ char	*display_prompt(char *buffer)
 	{
 		ft_strlcpy(buffer, RED, color_len);
 		ft_strlcpy(&buffer[ft_strlen(buffer)], "WHY THOUGH???", 14);
+		ft_strlcpy(&buffer[ft_strlen(buffer)], RESET_COLOR, reset_color_len);
 		return (buffer);
 	}
 	path_len = ft_strlen(path.buf) + 1;

--- a/src/parser/here_doc.c
+++ b/src/parser/here_doc.c
@@ -47,7 +47,7 @@ static void	cleanup_here_doc(char *line, int fd)
 
 /*
 	syntax checker responsible for assuring that this is only entered
-	when ere is a valid here_doc token
+	when there is a valid here_doc token
 */
 int	handle_here_doc(const char *delimeter)
 {
@@ -62,7 +62,7 @@ int	handle_here_doc(const char *delimeter)
 	while (TRUE)
 	{
 		line = readline("> ");
-		if (append_line_to_heredoc(line, delimeter, fd) == ERROR)
+		if (!line || append_line_to_heredoc(line, delimeter, fd) == ERROR)
 			break ;
 		free(line);
 	}

--- a/src/parser/parse_redirection.c
+++ b/src/parser/parse_redirection.c
@@ -45,6 +45,8 @@ int	get_redirect_id(const char *cursor)
 
 void	open_in_mode(const char *file, t_files *files, int mode_id)
 {
+	if (files->in == FILE_ERROR)
+		return ;
 	if (mode_id == LEFT_ANGLE || mode_id == DIAMOND_BRACKETS)
 		open_infile(file, &files->in);
 	else if (mode_id == FT_TRUNCATE || mode_id == FT_APPEND)

--- a/tests/acceptance/pwd_feature_bash.sh
+++ b/tests/acceptance/pwd_feature_bash.sh
@@ -14,7 +14,15 @@ printTestName "PWD"
 
 run "pwd" "Just pwd"
 run "pwd blah blah echo" "pwd followed by random things"
-
 cleanUp
+
+
+STD=$(echo -e "mkdir test\ncd test\nrm -r ../test\npwd\nexit" | ./minishell > $MINISHELL_OUTPUT)
+removePrompt $MINISHELL_OUTPUT
+ACTUAL=$(cat $MINISHELL_OUTPUT)
+EXPECTED=$(mkdir test && cd test && rm -r ../test && pwd)
+assertEqual "pwd within a removed file"
+cleanUp
+
 
 exit $EXIT_CODE


### PR DESCRIPTION
Added an extra if statement when opening files, this way they still get parsed and replaced by spaces, but dont actually open so the fd stays as -2 (FILE_ERROR)