### PR TITLE
Signal fix

### DIFF
--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -21,7 +21,6 @@ static void	reprompt(int signal_code)
 static void	prep_repromt(int signal_code)
 {
 	(void)signal_code;
-	ft_putstr_fd("\n", STDOUT_FILENO);
 }
 
 void	set_program_signals(void)

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -27,7 +27,6 @@ void	set_program_signals(void)
 {
 	signal(SIGINT, reprompt);
 	signal(SIGQUIT, SIG_IGN);
-	rl_event_hook = reset_rl_event;
 }
 
 void	handle_quit(int signal_code)


### PR DESCRIPTION
Hi  Monique. I was looking at signals cause V had some questions, and I realized we do some unnecessary things.

prep_reprompt prints an extra line for every shell level, now it only re_prompts on a new line.

